### PR TITLE
Testing for Group Routes [OLD]

### DIFF
--- a/backend/tests/test_groups.py
+++ b/backend/tests/test_groups.py
@@ -1,0 +1,519 @@
+"""
+Contract-level tests for the /api/groups endpoint
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.future import select
+
+from models import Group, User
+
+pytest_plugins = ["tests.test_groups_helper"]
+
+
+# Route: /api/groups
+# Request: GET
+# Response: List[GroupResponse]
+@pytest.mark.asyncio
+async def test_get_all_groups_admin(client: AsyncClient, admin_headers, seeded_db):
+    response = await client.get("/api/groups", headers=admin_headers)
+    assert response.status_code == 200
+
+    # Make sure the response fulfills the API contract
+    groups = response.json()
+
+    for group in groups:
+        assert "name" in group
+        assert "id" in group
+        assert "created_by" in group
+        assert "created_at" in group
+        assert "updated_at" in group
+
+    # Make sure the request actually works
+    group_names = [group["name"] for group in groups]
+    assert "group_users" in group_names
+    assert "group_managers" in group_names
+    assert "group_admins" in group_names
+
+
+@pytest.mark.asyncio
+async def test_get_all_groups_manager(client: AsyncClient, manager_headers, seeded_db):
+    response = await client.get("/api/groups", headers=manager_headers)
+    assert response.status_code == 200
+
+    groups = response.json()
+    group_names = [group["name"] for group in groups]
+    assert "group_users" in group_names
+    assert "group_managers" in group_names
+    assert "group_admins" in group_names
+
+
+@pytest.mark.asyncio
+async def test_get_all_groups_user(client: AsyncClient, user_headers, seeded_db):
+    response = await client.get("/api/groups", headers=user_headers)
+    assert response.status_code == 200
+
+    groups = response.json()
+    group_names = [group["name"] for group in groups]
+    assert "group_users" in group_names
+    assert "group_managers" not in group_names
+    assert "group_admins" not in group_names
+
+
+@pytest.mark.asyncio
+async def test_get_all_groups_requires_auth(client: AsyncClient, seeded_db):
+    response = await client.get("/api/groups")
+    assert response.status_code == 401
+
+
+# Route: /api/groups/{id}
+# Request: GET
+# Response: GroupDetailResponse
+@pytest.mark.asyncio
+async def test_get_group_by_id_admin(client: AsyncClient, admin_headers, seeded_db):
+    session = seeded_db
+
+    result = await session.execute(select(Group).where(Group.name == "group_admins"))
+    group = result.scalar_one()
+    group_id = group.id
+
+    response = await client.get(f"/api/groups/{group_id}", headers=admin_headers)
+    assert response.status_code == 200
+
+    # Make sure the response fulfills the API contract
+    group = response.json()
+    assert "name" in group
+    assert "id" in group
+    assert "created_by" in group
+    assert "created_at" in group
+    assert "updated_at" in group
+    assert "members" in group
+
+    # Make sure the request actually works
+    assert group["id"] == group_id
+    # assert any(member["username"] == "admin" for member in group["members"])
+
+
+@pytest.mark.asyncio
+async def test_get_group_by_id_admin_access(
+    client: AsyncClient, admin_headers, seeded_db, normal_user
+):
+    session = seeded_db
+
+    result = await session.execute(select(Group).where(Group.name == "group_users"))
+    group = result.scalar_one()
+    group_id = group.id
+
+    response = await client.get(f"/api/groups/{group_id}", headers=admin_headers)
+    assert response.status_code == 200
+
+    group = response.json()
+    assert group["id"] == group_id
+    assert any(member["username"] == "user" for member in group["members"])
+
+
+@pytest.mark.asyncio
+async def test_get_group_by_id_manager(client: AsyncClient, manager_headers, seeded_db):
+    session = seeded_db
+
+    result = await session.execute(select(Group).where(Group.name == "group_managers"))
+    group = result.scalar_one()
+    group_id = group.id
+
+    response = await client.get(f"/api/groups/{group_id}", headers=manager_headers)
+    assert response.status_code == 200
+
+    group = response.json()
+    assert group["id"] == group_id
+    assert any(member["username"] == "manager" for member in group["members"])
+
+
+@pytest.mark.asyncio
+async def test_get_group_by_id_manager_access(
+    client: AsyncClient, manager_headers, seeded_db, normal_user
+):
+    session = seeded_db
+
+    result = await session.execute(select(Group).where(Group.name == "group_users"))
+    group = result.scalar_one()
+    group_id = group.id
+
+    response = await client.get(f"/api/groups/{group_id}", headers=manager_headers)
+    assert response.status_code == 200
+
+    group = response.json()
+    assert group["id"] == group_id
+    assert any(member["username"] == "user" for member in group["members"])
+
+
+@pytest.mark.asyncio
+async def test_get_group_by_id_user(client: AsyncClient, user_headers, seeded_db):
+    session = seeded_db
+
+    result = await session.execute(select(Group).where(Group.name == "group_users"))
+    group = result.scalar_one()
+    group_id = group.id
+
+    response = await client.get(f"/api/groups/{group_id}", headers=user_headers)
+    assert response.status_code == 200
+
+    group = response.json()
+    assert group["id"] == group_id
+    assert any(member["username"] == "user" for member in group["members"])
+
+
+@pytest.mark.asyncio
+async def test_get_group_by_id_requires_auth(client: AsyncClient, seeded_db):
+    session = seeded_db
+
+    result = await session.execute(select(Group).where(Group.name == "group_users"))
+    group = result.scalar_one()
+    group_id = group.id
+
+    response = await client.get(f"/api/groups/{group_id}")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_group_id_insufficient_permission(
+    client: AsyncClient, user_headers, seeded_db
+):
+    session = seeded_db
+
+    result = await session.execute(select(Group).where(Group.name == "group_admins"))
+    group = result.scalar_one()
+    group_id = group.id
+
+    response = await client.get(f"/api/groups/{group_id}", headers=user_headers)
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_group_id_not_found(client: AsyncClient, admin_headers, seeded_db):
+    group_id = -1
+    response = await client.get(f"/api/groups/{group_id}", headers=admin_headers)
+    assert response.status_code == 404
+
+
+# Route: /api/groups
+# Request: POST
+# Response: GroupResponse
+@pytest.mark.asyncio
+async def test_create_group_admin(client: AsyncClient, admin_headers, seeded_db):
+    session = seeded_db
+
+    result = await session.execute(select(User).where(User.username == "admin"))
+    creator = result.scalar_one()
+    creator_id = creator.id
+
+    group_data = {
+        "name": "group_admin_test",
+        "description": "this is a test admin group",
+        "created_by": creator_id,
+    }
+    response = await client.post("/api/groups", json=group_data, headers=admin_headers)
+    assert response.status_code == 201
+
+    # Make sure the response fulfills the API contract
+    group = response.json()
+    assert "name" in group
+    assert group["name"] == "group_admin_test"
+    assert "description" in group
+    assert group["description"] == "this is a test admin group"
+    assert "id" in group
+    assert "created_by" in group
+    assert "created_at" in group
+    assert "updated_at" in group
+
+    # Make sure the request actually works
+    group_id = group["id"]
+    response = await client.get(f"/api/groups/{group_id}", headers=admin_headers)
+    assert response.status_code == 200
+
+    group = response.json()
+    assert group["name"] == "group_admin_test"
+    assert group["description"] == "this is a test admin group"
+
+
+@pytest.mark.asyncio
+async def test_create_group_manager(client: AsyncClient, manager_headers, seeded_db):
+    session = seeded_db
+
+    result = await session.execute(select(User).where(User.username == "manager"))
+    creator = result.scalar_one()
+    creator_id = creator.id
+
+    group_data = {
+        "name": "group_manager_test",
+        "description": "this is a test manager group",
+        "created_by": creator_id,
+    }
+    response = await client.post(
+        "/api/groups", json=group_data, headers=manager_headers
+    )
+    assert response.status_code == 201
+
+    group = response.json()
+    group_id = group["id"]
+    response = await client.get(f"/api/groups/{group_id}", headers=manager_headers)
+    assert response.status_code == 200
+
+    group = response.json()
+    assert group["name"] == "group_manager_test"
+    assert group["description"] == "this is a test manager group"
+
+
+@pytest.mark.asyncio
+async def test_create_group_empty_name(client: AsyncClient, admin_headers, seeded_db):
+    session = seeded_db
+
+    result = await session.execute(select(User).where(User.username == "admin"))
+    creator = result.scalar_one()
+    creator_id = creator.id
+
+    group_data = {
+        "name": " ",
+        "description": "this is a test group whose name is just whitespace!",
+        "created_by": creator_id,
+    }
+    response = await client.post("/api/groups", json=group_data, headers=admin_headers)
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_group_requires_auth(client: AsyncClient, seeded_db):
+    group_data = {}
+    response = await client.post("/api/groups", json=group_data)
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_create_group_insufficient_permission(
+    client: AsyncClient, user_headers, seeded_db
+):
+    session = seeded_db
+
+    result = await session.execute(select(User).where(User.username == "user"))
+    creator = result.scalar_one()
+    creator_id = creator.id
+
+    group_data = {
+        "name": "group_user_test",
+        "description": "this is a test user group",
+        "created_by": creator_id,
+    }
+    response = await client.post("/api/groups", json=group_data, headers=user_headers)
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_group_invalid_input(
+    client: AsyncClient, admin_headers, seeded_db
+):
+    group_data = {}
+    response = await client.post("/api/groups", json=group_data, headers=admin_headers)
+    assert response.status_code == 422
+
+
+# Route: /api/groups/{id}
+# Request: PATCH
+# Response: GroupResponse
+@pytest.mark.asyncio
+async def test_update_group_admin(client: AsyncClient, admin_headers, seeded_db):
+    session = seeded_db
+
+    result = await session.execute(select(Group).where(Group.name == "group_admins"))
+    group = result.scalar_one()
+    group_id = group.id
+
+    group_data = {
+        "name": "group_admin_updated",
+        "description": "this is an updated admin group",
+    }
+    response = await client.patch(
+        f"/api/groups/{group_id}", json=group_data, headers=admin_headers
+    )
+    assert response.status_code == 200
+
+    # Make sure the response fulfills the API contract
+    group = response.json()
+    assert "name" in group
+    assert group["name"] == "group_admin_updated"
+    assert "description" in group
+    assert group["description"] == "this is an updated admin group"
+    assert "id" in group
+    assert "created_by" in group
+    assert "created_at" in group
+    assert "updated_at" in group
+
+    # Make sure the request actually works
+    response = await client.get(f"/api/groups/{group_id}", headers=admin_headers)
+    assert response.status_code == 200
+
+    group = response.json()
+    assert group["name"] == "group_admin_updated"
+    assert group["description"] == "this is an updated admin group"
+
+
+@pytest.mark.asyncio
+async def test_update_group_manager(client: AsyncClient, manager_headers, seeded_db):
+    session = seeded_db
+
+    result = await session.execute(select(Group).where(Group.name == "group_managers"))
+    group = result.scalar_one()
+    group_id = group.id
+
+    group_data = {
+        "name": "group_manager_updated",
+        "description": "this is an updated manager group",
+    }
+    response = await client.patch(
+        f"/api/groups/{group_id}", json=group_data, headers=manager_headers
+    )
+    assert response.status_code == 200
+
+    response = await client.get(f"/api/groups/{group_id}", headers=manager_headers)
+    assert response.status_code == 200
+
+    group = response.json()
+    assert group["name"] == "group_manager_updated"
+    assert group["description"] == "this is an updated manager group"
+
+
+@pytest.mark.asyncio
+async def test_update_group_whitespace_error(
+    client: AsyncClient, admin_headers, seeded_db
+):
+    session = seeded_db
+
+    result = await session.execute(select(Group).where(Group.name == "group_admins"))
+    group = result.scalar_one()
+    group_id = group.id
+
+    group_data = {
+        "name": " ",
+        "description": "this is an updated group whose name is just whitespace!",
+    }
+    response = await client.patch(
+        f"/api/groups/{group_id}", json=group_data, headers=admin_headers
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_update_group_requires_auth(client: AsyncClient, seeded_db):
+    session = seeded_db
+
+    result = await session.execute(select(Group).where(Group.name == "group_users"))
+    group = result.scalar_one()
+    group_id = group.id
+
+    group_data = {
+        "name": "group_user_updated",
+        "description": "this is an updated user group",
+    }
+    response = await client.patch(f"/api/groups/{group_id}", json=group_data)
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_update_group_insufficient_permission(
+    client: AsyncClient, user_headers, seeded_db
+):
+    session = seeded_db
+
+    result = await session.execute(select(Group).where(Group.name == "group_users"))
+    group = result.scalar_one()
+    group_id = group.id
+
+    group_data = {
+        "name": "group_user_updated",
+        "description": "this is an updated user group",
+    }
+    response = await client.patch(
+        f"/api/groups/{group_id}", json=group_data, headers=user_headers
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_update_group_id_not_found(client: AsyncClient, admin_headers, seeded_db):
+    group_id = -1
+    group_data = {
+        "name": "group_secret_updated",
+        "description": "this is an updated secret group",
+    }
+    response = await client.patch(
+        f"/api/groups/{group_id}", json=group_data, headers=admin_headers
+    )
+    assert response.status_code == 404
+
+
+# Route: /api/groups/{id}
+# Request: DELETE
+# Response: None
+@pytest.mark.asyncio
+async def test_delete_group_admin(client: AsyncClient, admin_headers, seeded_db):
+    session = seeded_db
+
+    result = await session.execute(select(Group).where(Group.name == "group_admins"))
+    group = result.scalar_one()
+    group_id = group.id
+
+    response = await client.delete(f"/api/groups/{group_id}", headers=admin_headers)
+    assert response.status_code == 204
+
+    # Make sure the response fulfills the API contract
+    assert not response.content
+
+    # Make sure the request actually works
+    response = await client.get(f"/api/groups/{group_id}", headers=admin_headers)
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_group_manager(client: AsyncClient, manager_headers, seeded_db):
+    session = seeded_db
+
+    result = await session.execute(select(Group).where(Group.name == "group_managers"))
+    group = result.scalar_one()
+    group_id = group.id
+
+    response = await client.delete(f"/api/groups/{group_id}", headers=manager_headers)
+    assert response.status_code == 204
+
+    response = await client.get(f"/api/groups/{group_id}", headers=manager_headers)
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_group_requires_auth(client: AsyncClient, seeded_db):
+    session = seeded_db
+
+    result = await session.execute(select(Group).where(Group.name == "group_users"))
+    group = result.scalar_one()
+    group_id = group.id
+
+    response = await client.delete(f"/api/groups/{group_id}")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_delete_group_insufficient_permission(
+    client: AsyncClient, user_headers, seeded_db
+):
+    session = seeded_db
+
+    result = await session.execute(select(Group).where(Group.name == "group_users"))
+    group = result.scalar_one()
+    group_id = group.id
+
+    response = await client.delete(f"/api/groups/{group_id}", headers=user_headers)
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_delete_group_id_not_found(client: AsyncClient, admin_headers, seeded_db):
+    group_id = -1
+    response = await client.delete(f"/api/groups/{group_id}", headers=admin_headers)
+    assert response.status_code == 404

--- a/backend/tests/test_groups_helper.py
+++ b/backend/tests/test_groups_helper.py
@@ -1,0 +1,239 @@
+"""
+Pytest fixtures for testing the group schema
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from sqlalchemy.orm import joinedload, sessionmaker
+
+from models import Group, Role, User, UserGroup
+from server import app
+
+
+@pytest.fixture(scope="function")
+async def seeded_db(test_db):
+    TestSessionLocal = sessionmaker(
+        test_db, class_=AsyncSession, expire_on_commit=False
+    )
+
+    # Seed required roles
+    async with TestSessionLocal() as session:
+
+        # Get admin role (already created by test_db fixture)
+        result = await session.execute(select(Role).where(Role.name == "admin"))
+        admin_role = result.scalar_one()
+
+        # Create super admin
+        sadmin = User(
+            username="sadmin",
+            email="sadmin@test.com",
+            hashed_password="$2b$12$dummy",  # Dummy hash for testing
+            role_id=admin_role.id,
+            is_active=True,
+        )
+        session.add(sadmin)
+        await session.commit()
+        await session.refresh(sadmin)
+
+        # Create all required groups
+        groups = [
+            Group(name="group_users", created_by=sadmin.id),
+            Group(name="group_managers", created_by=sadmin.id),
+            Group(name="group_admins", created_by=sadmin.id),
+        ]
+        for group in groups:
+            session.add(group)
+        await session.commit()
+
+        yield session
+
+
+@pytest.fixture
+async def admin_user(seeded_db):
+    """Create an admin user for testing (roles already exist from test_db fixture)"""
+    session = seeded_db
+
+    # Get admin role (already created by test_db fixture)
+    result = await session.execute(select(Role).where(Role.name == "admin"))
+    admin_role = result.scalar_one()
+
+    # Create admin
+    admin = User(
+        username="admin",
+        email="admin@test.com",
+        hashed_password="$2b$12$dummy",  # Dummy hash for testing
+        role_id=admin_role.id,
+        is_active=True,
+    )
+    session.add(admin)
+    await session.commit()
+    await session.refresh(admin)
+
+    # Get admin group
+    result = await session.execute(select(Group).where(Group.name == "group_admins"))
+    group = result.scalar_one()
+
+    # Add admin to group
+    membership = UserGroup(
+        user_id=admin.id,
+        group_id=group.id,
+        role="member",
+    )
+    session.add(membership)
+    await session.commit()
+
+    # Load role relationship
+    result = await session.execute(
+        select(User).where(User.id == admin.id).options(joinedload(User.role))
+    )
+    admin_with_role = result.scalar_one()
+
+    return admin_with_role
+
+
+@pytest.fixture
+async def admin_headers(client, admin_user, seeded_db):
+    """Get authentication headers by overriding auth dependencies"""
+    from auth import get_current_user, require_admin
+
+    async def override_get_current_user():
+        return admin_user
+
+    async def override_require_admin():
+        return admin_user
+
+    # Override authentication dependencies to return our test admin user
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    app.dependency_overrides[require_admin] = override_require_admin
+
+    yield {"Authorization": "Bearer test-token"}
+
+    # Clean up overrides after test
+    app.dependency_overrides.pop(get_current_user, None)
+    app.dependency_overrides.pop(require_admin, None)
+
+
+@pytest.fixture
+async def manager_user(seeded_db):
+    """Create a manager user for testing (roles already exist from test_db fixture)"""
+    session = seeded_db
+
+    # Get manager role (already created by test_db fixture)
+    result = await session.execute(select(Role).where(Role.name == "manager"))
+    manager_role = result.scalar_one()
+
+    # Create manager
+    manager = User(
+        username="manager",
+        email="manager@test.com",
+        hashed_password="$2b$12$dummy",  # Dummy hash for testing
+        role_id=manager_role.id,
+        is_active=True,
+    )
+    session.add(manager)
+    await session.commit()
+    await session.refresh(manager)
+
+    # Get manager group
+    result = await session.execute(select(Group).where(Group.name == "group_managers"))
+    group = result.scalar_one()
+
+    # Add manager to group
+    membership = UserGroup(
+        user_id=manager.id,
+        group_id=group.id,
+        role="member",
+    )
+    session.add(membership)
+    await session.commit()
+
+    # Load role relationship
+    result = await session.execute(
+        select(User).where(User.id == manager.id).options(joinedload(User.role))
+    )
+    manager_with_role = result.scalar_one()
+
+    return manager_with_role
+
+
+@pytest.fixture
+async def manager_headers(client, manager_user, seeded_db):
+    """Get authentication headers by overriding auth dependencies"""
+    from auth import get_current_user, require_admin
+
+    async def override_get_current_user():
+        return manager_user
+
+    async def override_require_admin():
+        return manager_user
+
+    # Override authentication dependencies to return our test manager user
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    app.dependency_overrides[require_admin] = override_require_admin
+
+    yield {"Authorization": "Bearer test-token"}
+
+    # Clean up overrides after test
+    app.dependency_overrides.pop(get_current_user, None)
+    app.dependency_overrides.pop(require_admin, None)
+
+
+@pytest.fixture
+async def normal_user(seeded_db):
+    """Create a normal user for testing (roles already exist from test_db fixture)"""
+    session = seeded_db
+
+    # Get user role (already created by test_db fixture)
+    result = await session.execute(select(Role).where(Role.name == "user"))
+    user_role = result.scalar_one()
+
+    # Create user
+    user = User(
+        username="user",
+        email="user@test.com",
+        hashed_password="$2b$12$dummy",  # Dummy hash for testing
+        role_id=user_role.id,
+        is_active=True,
+    )
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+
+    # Get user group
+    result = await session.execute(select(Group).where(Group.name == "group_users"))
+    group = result.scalar_one()
+
+    # Add user to group
+    membership = UserGroup(
+        user_id=user.id,
+        group_id=group.id,
+        role="member",
+    )
+    session.add(membership)
+    await session.commit()
+
+    # Load role relationship
+    result = await session.execute(
+        select(User).where(User.id == user.id).options(joinedload(User.role))
+    )
+    user_with_role = result.scalar_one()
+
+    return user_with_role
+
+
+@pytest.fixture
+async def user_headers(client, normal_user, seeded_db):
+    """Get authentication headers by overriding auth dependencies"""
+    from auth import get_current_user
+
+    async def override_get_current_user():
+        return normal_user
+
+    # Override authentication dependencies to return our test normal user
+    app.dependency_overrides[get_current_user] = override_get_current_user
+
+    yield {"Authorization": "Bearer test-token"}
+
+    # Clean up overrides after test
+    app.dependency_overrides.pop(get_current_user, None)


### PR DESCRIPTION
I implemented testing for the following endpoints:

- GET: /api/groups (closes #17)
- GET: /api/groups/{id} (closes #18)
- POST: /api/groups (closes #19)
- PATCH: /api/groups/{id} (closes #20)
- DELETE: /api/groups/{id} (closes #21)

These endpoints enable users to view, edit, and delete groups, as well as check that users have sufficient permission to perform the listed actions.

