### PR TITLE
fix critcal bug allowing anyone to create admin account, add tests fo…

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -28,6 +28,7 @@ ACCESS_TOKEN_EXPIRE_MINUTES = 30
 
 # Security scheme for Swagger UI
 security_scheme = HTTPBearer()
+optional_bearer = HTTPBearer(auto_error=False)
 
 
 def _prehash_password(password: str) -> bytes:
@@ -185,6 +186,41 @@ async def get_current_user(
         raise credentials_exception
 
     return authenticated_user
+
+
+async def get_bearer_token_optional(
+    credentials: HTTPAuthorizationCredentials | None = Security(optional_bearer),
+) -> str | None:
+    """Extract Bearer token from Authorization header if present."""
+    if credentials is None:
+        return None
+    return credentials.credentials
+
+
+async def get_current_user_optional(
+    token: str | None = Depends(get_bearer_token_optional),
+    db: AsyncSession = Depends(get_db),
+) -> User | None:
+    """
+    Get the current user from JWT if present and valid; otherwise None.
+    Use for endpoints that work both authenticated and anonymous (e.g. register).
+    """
+    if token is None:
+        return None
+    from sqlalchemy.orm import joinedload
+
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str = payload.get("sub")
+        if username is None:
+            return None
+    except JWTError:
+        return None
+
+    result = await db.execute(
+        select(User).where(User.username == username).options(joinedload(User.role))
+    )
+    return result.scalar_one_or_none()
 
 
 async def get_current_active_user(

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -15,6 +15,7 @@ from auth import (
     authenticate_user,
     create_access_token,
     get_current_active_user,
+    get_current_user_optional,
     get_password_hash,
     get_user_by_email,
     get_user_by_id,
@@ -41,7 +42,11 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 
 
 @router.post("/register", response_model=UserResponse, status_code=201)
-async def register(user_data: UserCreate, db: AsyncSession = Depends(get_db)):
+async def register(
+    user_data: UserCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User | None = Depends(get_current_user_optional),
+):
     """
     Register a new user.
 
@@ -82,6 +87,17 @@ async def register(user_data: UserCreate, db: AsyncSession = Depends(get_db)):
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid role. Must be one of: {', '.join(valid_roles)}",
         )
+
+    if role_name in ("admin", "manager"):
+        if (
+            current_user is None
+            or current_user.role is None
+            or current_user.role.name != "admin"
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only admins can create accounts with admin or manager role.",
+            )
 
     # Get role from database
     role_result = await db.execute(select(Role).where(Role.name == role_name))

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -14,6 +14,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
+from auth import get_password_hash
 from database import get_db
 from models import Base, Role, User
 from server import app
@@ -154,6 +155,78 @@ async def admin_user(test_db):
         admin_with_role = result.scalar_one()
 
         yield admin_with_role  # Provide the user object to your test
+
+
+@pytest.fixture
+async def regular_user(test_db):
+    """
+    Create a regular user for testing
+
+    This fixture:
+    - Depends on test_db (so roles exist first)
+    - Creates a test user in the database
+    - Returns the user object with role relationship loaded
+
+    Use this when you need an authenticated admin user in your tests.
+    """
+    async with TestSessionLocal() as session:
+        from sqlalchemy.future import select
+        from sqlalchemy.orm import joinedload
+
+        # Get user role (already created by test_db fixture)
+        # We need to look it up because User requires a role_id foreign key
+        result = await session.execute(select(Role).where(Role.name == "user"))
+        user_role = result.scalar_one()
+
+        # Create user with test data
+        user = User(
+            username="user",
+            email="user@test.com",
+            # Dummy hash - we're not testing password hashing
+            hashed_password=get_password_hash("testpassword123"),
+            role_id=user_role.id,  # Link to the user role
+            is_active=True,
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)  # Refresh to get the ID that was generated
+
+        # Load the role relationship (so user.role is available,
+        # not just user.role_id)
+        # joinedload() eagerly loads the relationship in the same query
+        result = await session.execute(
+            select(User).where(User.id == user.id).options(joinedload(User.role))
+        )
+        user_with_role = result.scalar_one()
+
+        yield user_with_role  # Provide the user object to your test
+
+
+@pytest.fixture
+async def regular_user_auth_headers(client, regular_user, test_db):
+    """
+    Auth headers that make the app treat the request as the regular (non-admin) user.
+
+    Overrides get_current_user_optional (for /auth/register) and get_current_user
+    (for routes like /auth/users/disable that use require_admin).
+    Use for tests that need "logged in as regular user"
+    (e.g. assert 403 when creating admin or calling admin-only endpoints with a user).
+    """
+    from auth import get_current_user, get_current_user_optional
+
+    async def override_get_current_user_optional():
+        return regular_user
+
+    async def override_get_current_user():
+        return regular_user
+
+    app.dependency_overrides[get_current_user_optional] = (
+        override_get_current_user_optional
+    )
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    yield {"Authorization": "Bearer test-token"}
+    app.dependency_overrides.pop(get_current_user_optional, None)
+    app.dependency_overrides.pop(get_current_user, None)
 
 
 @pytest.fixture

--- a/backend/tests/routes/test_auth.py
+++ b/backend/tests/routes/test_auth.py
@@ -1,0 +1,558 @@
+"""
+Contract-level tests for the /api/auth endpoint
+
+These tests verify the API contract (behavior) from the client's perspective:
+- Status codes (200, 201, 404, 401, 422, etc.)
+- Response structure (JSON format, required fields)
+- Error messages (when things go wrong)
+- Authentication/Authorization (who can access what)
+
+They do NOT test implementation details - they test the API contract.
+
+Fixtures used (from tests/conftest.py):
+- client: AsyncClient for making HTTP requests to the API
+- auth_headers: Authentication headers (simulates logged-in admin user)
+- test_db: Test database (in-memory SQLite, created fresh for each test)
+- admin_user: Admin user fixture (created in test database)
+"""
+
+import pytest
+from httpx import AsyncClient
+from jose import jwt
+
+from auth import ALGORITHM, SECRET_KEY
+
+
+@pytest.mark.asyncio
+async def test_get_all_users_requires_auth(client: AsyncClient):
+    """
+    Test that GET /api/auth/users requires authentication
+
+    Contract: Unauthenticated requests should return 401 Unauthorized
+    This is a security requirement - users endpoint should be protected.
+    """
+    # Act: Make request without authentication headers
+    response = await client.get("/api/auth/users")
+    # Assert: Should return 401 (Unauthorized)
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_all_users_requires_admin(
+    client: AsyncClient, regular_user_auth_headers
+):
+    """
+    Test that GET /api/auth/users requires authentication
+
+    Contract: access to admin resources should require admin rights
+    """
+    # Act: Make request without authentication headers
+    response = await client.get("/api/auth/users", headers=regular_user_auth_headers)
+    # Assert: Should return 403 (Forbidden)
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_all_users_with_admin_auth(
+    client: AsyncClient, auth_headers, admin_user
+):
+    """
+    Test that GET /api/auth/users returns list of users when authenticated
+
+    Contract: Authenticated admin users can retrieve all users
+    - Status: 200 OK
+    - Response: List of user objects
+    - Each user should have: id, username, email, role
+    - Password should NEVER be in response (security)
+    """
+    # Act: Make authenticated request
+    response = await client.get("/api/auth/users", headers=auth_headers)
+
+    # Assert: Should return 200 OK
+    assert response.status_code == 200
+
+    # Assert: Response should be a list
+    data = response.json()
+    assert isinstance(data, list)
+
+    # Assert: List should contain at least the admin user
+    # (created by admin_user fixture)
+    assert len(data) >= 1
+
+    # Assert: Each user in the list should have the expected structure
+    # This verifies the response schema matches what the API contract promises
+    for user in data:
+        assert "id" in user
+        assert "username" in user
+        assert "email" in user
+        assert "role" in user
+        assert "password" not in user  # Security: Password should never be in response
+
+    # Assert: The admin user (from fixture) should be in the list
+    admin_usernames = [user["username"] for user in data]
+    assert "admin" in admin_usernames
+
+
+@pytest.mark.asyncio
+async def test_create_admin_requires_admin(
+    client: AsyncClient, regular_user_auth_headers
+):
+    """
+    Test that POST /api/auth/register
+
+    Only admins can create users with admin or manager role.
+    Contract: Authenticated non-admin gets 403 when registering with role admin/manager.
+    """
+    # Arrange: Prepare user data (valid format)
+    user_data = {
+        "username": "testuser",
+        "email": "test@example.com",
+        "password": "password123",
+        "role": "admin",
+    }
+
+    # Act: Call register with regular-user auth (non-admin)
+    response = await client.post(
+        "/api/auth/register", json=user_data, headers=regular_user_auth_headers
+    )
+
+    # Assert: Should return 403 (Forbidden - only admins can create admin/manager)
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_admin_requires_auth(client: AsyncClient):
+    """
+    Test that POST /api/auth/register requires auth to make an admin account.
+
+    Contract: Creating admin/manager accounts requires auth (unauthenticated gets 403).
+    """
+    # Arrange: Prepare user data (valid format)
+    user_data = {
+        "username": "testuser",
+        "email": "test@example.com",
+        "password": "password123",
+        "role": "admin",
+    }
+
+    # Act: Call register without authentication headers
+    response = await client.post("/api/auth/register", json=user_data)
+
+    # Assert: Should return 403 (Forbidden - must be authenticated admin)
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_user_without_auth_success(client: AsyncClient):
+    """
+    Test that POST /api/auth/register works for new users.
+    Auth/Admin is NOT required to make a new account, nor is auth.
+
+    Contract: New users can be made without being authenticated as a user/admin
+    """
+    # Arrange: Prepare user data (valid format)
+    user_data = {
+        "username": "testuser",
+        "email": "test@example.com",
+        "password": "password123",
+        "role": "user",
+    }
+
+    # Act: Call admin create-user endpoint without authentication headers
+    response = await client.post("/api/auth/register", json=user_data)
+
+    # Assert: Should return 201
+    assert response.status_code == 201
+
+    # Assert: Response should contain the created user data
+    data = response.json()
+    assert data["username"] == "testuser"
+    assert data["email"] == "test@example.com"
+    assert "id" in data  # User should have an ID assigned
+    assert "password" not in data  # Security: Password should never be in response
+
+
+@pytest.mark.asyncio
+async def test_create_user_with_auth_success(client: AsyncClient, auth_headers):
+    """
+    Test that POST /api/auth/register creates a user successfully
+
+    Contract: When creating a user with valid data:
+    - Status: 201 Created
+    - Response: User object with id, username, email, role
+    - Password should NOT be in response (security)
+
+    Note: test_db fixture ensures fresh database for each test
+    """
+    # Arrange: Prepare valid user data
+    user_data = {
+        "username": "newuser",
+        "email": "newuser@example.com",
+        "password": "password123",
+        "role": "user",
+    }
+
+    # Act: Create user with authenticated request
+    response = await client.post(
+        "/api/auth/register", json=user_data, headers=auth_headers
+    )
+
+    # Assert: Should return 201 Created
+    assert response.status_code == 201
+
+    # Assert: Response should contain the created user data
+    data = response.json()
+    assert data["username"] == "newuser"
+    assert data["email"] == "newuser@example.com"
+    assert "id" in data  # User should have an ID assigned
+    assert "password" not in data  # Security: Password should never be in response
+
+
+@pytest.mark.asyncio
+async def test_create_user_missing_fields(client: AsyncClient, auth_headers):
+    """
+    Test that POST /api/auth/register returns 422 for missing required fields
+
+    Contract: When creating a user with missing required fields:
+    - Status: 422 Unprocessable Entity (validation error)
+    - This tests input validation - the API should reject invalid data
+
+    Note: Even with authentication, invalid data should be rejected
+    """
+    # Arrange: Prepare user data with missing required fields (email and password)
+    user_data = {
+        "username": "testuser"
+        # Missing email and password - these are required fields
+    }
+
+    # Act: Try to create user with incomplete data
+    response = await client.post(
+        "/api/auth/register", json=user_data, headers=auth_headers
+    )
+
+    # Assert: Should return 422 (validation error)
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_user_duplicate_username(
+    client: AsyncClient, auth_headers, test_db
+):
+    """
+    Test that POST /api/auth/register returns error for duplicate username
+
+    Contract: When trying to create a user with a username that already exists:
+    - Status: 400 Bad Request (or similar error status)
+    - Error message should indicate username already exists
+    - Original user should remain unchanged
+
+    This tests uniqueness constraints and ensures the API prevents duplicate usernames.
+    """
+    # Arrange: Prepare user data for first user
+    user_data = {
+        "username": "duplicate",
+        "email": "first@example.com",
+        "password": "password123",
+        "role": "user",
+    }
+
+    # Act: Create first user
+    create_response = await client.post(
+        "/api/auth/register", json=user_data, headers=auth_headers
+    )
+
+    # Assert: First user should be created successfully
+    assert create_response.status_code == 201
+    first_user_id = create_response.json()["id"]
+
+    # Assert: Verify the first user was actually created in the database
+    get_response = await client.get(f"/api/users/{first_user_id}", headers=auth_headers)
+    assert get_response.status_code == 200
+    assert get_response.json()["username"] == "duplicate"
+
+    # Act: Try to create a second user with the same username (different email)
+    user_data["email"] = "second@example.com"
+    response = await client.post(
+        "/api/auth/register", json=user_data, headers=auth_headers
+    )
+
+    # Assert: Should return 400 with error message about duplicate username
+    assert response.status_code == 400
+    assert "already registered" in response.json()["detail"].lower()
+
+    # Assert: Original user should still exist and be unchanged
+    # This verifies that the duplicate attempt didn't affect the existing user
+    get_response = await client.get(f"/api/users/{first_user_id}", headers=auth_headers)
+    assert get_response.status_code == 200
+    assert (
+        get_response.json()["email"] == "first@example.com"
+    )  # Original email unchanged
+
+
+# tests for /auth/login
+@pytest.mark.asyncio
+async def test_invalid_login_password(client: AsyncClient):
+    """
+    Test POST /api/auth/login
+
+    Contract: should return 401:Invalid credentials (user not found or wrong password)
+    """
+    # Arrange: Prepare login data (valid format)
+    user_data = {
+        "username": "user",
+        # Dummy hash - we're not testing password hashing
+        "password": "wrong_password",
+    }
+
+    # Act: Call login
+    response = await client.post("/api/auth/login", json=user_data)
+
+    # Assert: Should return 401 (Invalid credentials (user not found or wrong password))
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_invalid_login_username(client: AsyncClient):
+    """
+    Test POST /api/auth/login
+
+    Contract: should return 401:Invalid credentials (user not found or wrong password)
+    """
+    # Arrange: Prepare login data (valid format)
+    user_data = {
+        "username": "wrong_user",
+        # Dummy hash - we're not testing password hashing
+        "password": "testpassword123",
+    }
+
+    # Act: Call login
+    response = await client.post("/api/auth/login", json=user_data)
+
+    # Assert: Should return 401 (Invalid credentials (user not found or wrong password))
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_invalid_login_format(client: AsyncClient):
+    """
+    Test POST /api/auth/login
+
+    Contract: should return 401:Invalid credentials (user not found or wrong password)
+    """
+    # Arrange: Prepare login data (valid format)
+    user_data = {
+        "user": "wrong_user",
+        # Dummy hash - we're not testing password hashing
+        "pass": "testpassword123",
+    }
+
+    # Act: Call login
+    response = await client.post("/api/auth/login", json=user_data)
+
+    # Assert: Should return 422 Validation error (invalid input format)
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_valid_login_credentials(
+    client: AsyncClient, regular_user
+):  # leave regular_user as a dependency!
+    """
+    Test POST /api/auth/login
+
+    Contract: should return Status: 200 OK
+    """
+    # Arrange: Prepare login data (valid format)
+    user_data = {
+        "username": "user",
+        "password": "testpassword123",
+    }
+
+    # Act: Call login
+    response = await client.post("/api/auth/login", json=user_data)
+
+    # Assert: Should return 200
+    assert response.status_code == 200
+
+    # now verify access_token and token_type
+    data = response.json()
+    assert "access_token" in data
+    assert isinstance(data["access_token"], str)
+    assert len(data["access_token"]) > 0
+    assert data.get("token_type", "").lower() == "bearer"
+
+    # now verify the payload (we accessed the correct profile)
+    payload = jwt.decode(data["access_token"], SECRET_KEY, algorithms=[ALGORITHM])
+    assert payload.get("sub") == "user"
+    assert "exp" in payload
+
+
+# tests for /auth/me
+@pytest.mark.asyncio
+async def test_get_me_requires_auth(client: AsyncClient):
+    """
+    Test that GET /api/auth/me requires authentication
+
+    Contract: Unauthenticated requests should return 401 Unauthorized
+    This is a security requirement - user endpoint should be protected.
+    """
+    # Act: Make request without authentication headers
+    response = await client.get("/api/auth/me")
+    # Assert: Should return 401 (Unauthorized)
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_me_success(client: AsyncClient, auth_headers, admin_user):
+    """
+    Test that GET /api/auth/me returns the user when authenticated
+
+    Contract: Authenticated user can retrieve themselves
+    - Status: 200 OK
+    - Response: user object
+    - Each user should have: id, username, email, role
+    - Password should NEVER be in response (security)
+    """
+    # Act: Make authenticated request
+    response = await client.get("/api/auth/me", headers=auth_headers)
+
+    # Assert: Should return 200 OK
+    assert response.status_code == 200
+
+    # Assert: Response should be a list
+    data = response.json()
+    # assert isinstance(data, list)
+
+    # Assert: List should contain data
+    assert len(data) >= 1
+
+    # Assert: user should have the expected structure
+    # This verifies the response schema matches what the API contract promises
+    assert "id" in data
+    assert "username" in data
+    assert "email" in data
+    assert "role" in data
+    assert "password" not in data  # Security: Password should never be in response
+    assert data["role"]["name"] == "admin"  # the correct prems
+    assert data["username"] == "admin"  # the correct user
+
+
+# tests for  /auth/users/disable
+@pytest.mark.asyncio
+async def test_disable_user_requires_auth(
+    client: AsyncClient, regular_user, admin_user
+):
+    """
+    Test that PATCH /api/auth/users/disable requires authentication
+
+    Contract: Unauthenticated requests should return 401 Unauthorized
+    This is a security requirement - user endpoint should be protected.
+    """
+    # Prepare request body (valid format)
+    #    user_id: int
+    #    is_active: bool
+    user_data = {
+        "user_id": "2",
+        "is_active": "false",
+    }
+
+    # Act: Make request without authentication headers
+    response = await client.patch("api/auth/users/disable", json=user_data)
+    # Assert: Should return 401 (Unauthorized)
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_disable_user_requires_admin(
+    client: AsyncClient, regular_user_auth_headers
+):
+    """
+    Test that PATCH /api/auth/users/disable requires admin prems
+
+    Contract: access to admin resources should require admin rights
+    """
+    # Prepare request body (valid format)
+    user_data = {
+        "user_id": "2",
+        "is_active": "false",
+    }
+    # Act: Make request with regular user headers
+    response = await client.patch(
+        "api/auth/users/disable", json=user_data, headers=regular_user_auth_headers
+    )
+    # Assert: Should return 403 (Forbidden)
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_disable_self_fails(client: AsyncClient, auth_headers):
+    """
+    Test that PATCH /api/auth/users/disable
+
+    Contract: errors out if trying to disable yourself
+    """
+    # Prepare request body (valid format)
+    user_data = {
+        "user_id": "1",
+        "is_active": "false",
+    }
+    # Act: Make request without authentication headers
+    response = await client.patch(
+        "api/auth/users/disable", json=user_data, headers=auth_headers
+    )
+    # Assert: Should return 400: bad request (trying to disable your own account)
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_disable_fake_account_fails(client: AsyncClient, auth_headers):
+    """
+    Test that PATCH /api/auth/users/disable
+
+    Contract: errors out if trying to disable a non-existent user
+    """
+    # Prepare request body (valid format)
+    user_data = {
+        "user_id": "9999",
+        "is_active": "false",
+    }
+    # Act: Make bad request
+    response = await client.patch(
+        "api/auth/users/disable", json=user_data, headers=auth_headers
+    )
+    # Assert: Should return 404: (user not found)
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_disable_user_success(client: AsyncClient, auth_headers, regular_user):
+    """
+    Test that PATCH /api/auth/users/disable
+
+    Contract: errors out if trying to disable a non-existent user
+    """
+    # Prepare request body (valid format)
+    user_data = {
+        "user_id": "2",
+        "is_active": "false",
+    }
+    # Act: Make bad request
+    response = await client.patch(
+        "api/auth/users/disable", json=user_data, headers=auth_headers
+    )
+    # Assert: Should return 200
+    assert response.status_code == 200
+
+    data = response.json()
+    # Assert: userResponse should have the expected structure
+    # This verifies the response schema matches what the API contract promises
+    assert data["id"] == regular_user.id
+    assert "username" in data
+    assert "email" in data
+    assert "role" in data
+    assert "password" not in data  # Security: Password should never be in response
+    assert data["role"]["name"] == "user"
+    assert data["username"] == "user"  # the correct user
+
+    # verify disable went through
+    assert data["is_active"] is False


### PR DESCRIPTION
# Summary

This pr aims to address a critical bug in the create user endpoint, while also adding comprehensive tests for the auth endpoint in general.

- #11 is resolved with my changes in `auth.py` and tests verify intended functionality
- Conftest was updated to create a user level account for checking privileged access to resources, i.e. we should get 403 when accessing admin resource endpoints.
- #7 **/api/auth/users**
- #4 /api/auth/register
- #5 /api/auth/login
- #6 /api/auth/me
- #8 /api/auth/users/disable