### PR TITLE
HW 3: Refactor of Group API Tests

### DIFF
--- a/backend/tests/routes/test_groups.py
+++ b/backend/tests/routes/test_groups.py
@@ -4,9 +4,6 @@ Contract-level tests for the /api/groups endpoint
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy.future import select
-
-from models import Group, User
 
 pytest_plugins = ["tests.routes.test_groups_helper"]
 
@@ -70,11 +67,10 @@ async def test_get_all_groups_requires_auth(client: AsyncClient, seeded_db):
 # Request: GET
 # Response: GroupDetailResponse
 @pytest.mark.asyncio
-async def test_get_group_by_id_admin(client: AsyncClient, admin_headers, seeded_db):
-    session = seeded_db
-
-    result = await session.execute(select(Group).where(Group.name == "group_admins"))
-    group = result.scalar_one()
+async def test_get_group_by_id_admin(
+    client: AsyncClient, admin_headers, admin_group, seeded_db
+):
+    group = admin_group
     group_id = group.id
 
     response = await client.get(f"/api/groups/{group_id}", headers=admin_headers)
@@ -96,12 +92,9 @@ async def test_get_group_by_id_admin(client: AsyncClient, admin_headers, seeded_
 
 @pytest.mark.asyncio
 async def test_get_group_by_id_admin_access(
-    client: AsyncClient, admin_headers, seeded_db, normal_user
+    client: AsyncClient, admin_headers, normal_user, user_group, seeded_db
 ):
-    session = seeded_db
-
-    result = await session.execute(select(Group).where(Group.name == "group_users"))
-    group = result.scalar_one()
+    group = user_group
     group_id = group.id
 
     response = await client.get(f"/api/groups/{group_id}", headers=admin_headers)
@@ -113,11 +106,10 @@ async def test_get_group_by_id_admin_access(
 
 
 @pytest.mark.asyncio
-async def test_get_group_by_id_manager(client: AsyncClient, manager_headers, seeded_db):
-    session = seeded_db
-
-    result = await session.execute(select(Group).where(Group.name == "group_managers"))
-    group = result.scalar_one()
+async def test_get_group_by_id_manager(
+    client: AsyncClient, manager_headers, manager_group, seeded_db
+):
+    group = manager_group
     group_id = group.id
 
     response = await client.get(f"/api/groups/{group_id}", headers=manager_headers)
@@ -130,12 +122,9 @@ async def test_get_group_by_id_manager(client: AsyncClient, manager_headers, see
 
 @pytest.mark.asyncio
 async def test_get_group_by_id_manager_access(
-    client: AsyncClient, manager_headers, seeded_db, normal_user
+    client: AsyncClient, manager_headers, normal_user, user_group, seeded_db
 ):
-    session = seeded_db
-
-    result = await session.execute(select(Group).where(Group.name == "group_users"))
-    group = result.scalar_one()
+    group = user_group
     group_id = group.id
 
     response = await client.get(f"/api/groups/{group_id}", headers=manager_headers)
@@ -147,11 +136,10 @@ async def test_get_group_by_id_manager_access(
 
 
 @pytest.mark.asyncio
-async def test_get_group_by_id_user(client: AsyncClient, user_headers, seeded_db):
-    session = seeded_db
-
-    result = await session.execute(select(Group).where(Group.name == "group_users"))
-    group = result.scalar_one()
+async def test_get_group_by_id_user(
+    client: AsyncClient, user_headers, user_group, seeded_db
+):
+    group = user_group
     group_id = group.id
 
     response = await client.get(f"/api/groups/{group_id}", headers=user_headers)
@@ -163,11 +151,10 @@ async def test_get_group_by_id_user(client: AsyncClient, user_headers, seeded_db
 
 
 @pytest.mark.asyncio
-async def test_get_group_by_id_requires_auth(client: AsyncClient, seeded_db):
-    session = seeded_db
-
-    result = await session.execute(select(Group).where(Group.name == "group_users"))
-    group = result.scalar_one()
+async def test_get_group_by_id_requires_auth(
+    client: AsyncClient, user_group, seeded_db
+):
+    group = user_group
     group_id = group.id
 
     response = await client.get(f"/api/groups/{group_id}")
@@ -176,12 +163,9 @@ async def test_get_group_by_id_requires_auth(client: AsyncClient, seeded_db):
 
 @pytest.mark.asyncio
 async def test_get_group_id_insufficient_permission(
-    client: AsyncClient, user_headers, seeded_db
+    client: AsyncClient, user_headers, admin_group, seeded_db
 ):
-    session = seeded_db
-
-    result = await session.execute(select(Group).where(Group.name == "group_admins"))
-    group = result.scalar_one()
+    group = admin_group
     group_id = group.id
 
     response = await client.get(f"/api/groups/{group_id}", headers=user_headers)
@@ -199,11 +183,10 @@ async def test_get_group_id_not_found(client: AsyncClient, admin_headers, seeded
 # Request: POST
 # Response: GroupResponse
 @pytest.mark.asyncio
-async def test_create_group_admin(client: AsyncClient, admin_headers, seeded_db):
-    session = seeded_db
-
-    result = await session.execute(select(User).where(User.username == "admin"))
-    creator = result.scalar_one()
+async def test_create_group_admin(
+    client: AsyncClient, admin_user_g, admin_headers, seeded_db
+):
+    creator = admin_user_g
     creator_id = creator.id
 
     group_data = {
@@ -236,11 +219,10 @@ async def test_create_group_admin(client: AsyncClient, admin_headers, seeded_db)
 
 
 @pytest.mark.asyncio
-async def test_create_group_manager(client: AsyncClient, manager_headers, seeded_db):
-    session = seeded_db
-
-    result = await session.execute(select(User).where(User.username == "manager"))
-    creator = result.scalar_one()
+async def test_create_group_manager(
+    client: AsyncClient, manager_user, manager_headers, seeded_db
+):
+    creator = manager_user
     creator_id = creator.id
 
     group_data = {
@@ -264,11 +246,10 @@ async def test_create_group_manager(client: AsyncClient, manager_headers, seeded
 
 
 @pytest.mark.asyncio
-async def test_create_group_empty_name(client: AsyncClient, admin_headers, seeded_db):
-    session = seeded_db
-
-    result = await session.execute(select(User).where(User.username == "admin"))
-    creator = result.scalar_one()
+async def test_create_group_empty_name(
+    client: AsyncClient, admin_user_g, admin_headers, seeded_db
+):
+    creator = admin_user_g
     creator_id = creator.id
 
     group_data = {
@@ -289,12 +270,9 @@ async def test_create_group_requires_auth(client: AsyncClient, seeded_db):
 
 @pytest.mark.asyncio
 async def test_create_group_insufficient_permission(
-    client: AsyncClient, user_headers, seeded_db
+    client: AsyncClient, normal_user, user_headers, seeded_db
 ):
-    session = seeded_db
-
-    result = await session.execute(select(User).where(User.username == "user"))
-    creator = result.scalar_one()
+    creator = normal_user
     creator_id = creator.id
 
     group_data = {
@@ -319,11 +297,10 @@ async def test_create_group_invalid_input(
 # Request: PATCH
 # Response: GroupResponse
 @pytest.mark.asyncio
-async def test_update_group_admin(client: AsyncClient, admin_headers, seeded_db):
-    session = seeded_db
-
-    result = await session.execute(select(Group).where(Group.name == "group_admins"))
-    group = result.scalar_one()
+async def test_update_group_admin(
+    client: AsyncClient, admin_headers, admin_group, seeded_db
+):
+    group = admin_group
     group_id = group.id
 
     group_data = {
@@ -356,11 +333,10 @@ async def test_update_group_admin(client: AsyncClient, admin_headers, seeded_db)
 
 
 @pytest.mark.asyncio
-async def test_update_group_manager(client: AsyncClient, manager_headers, seeded_db):
-    session = seeded_db
-
-    result = await session.execute(select(Group).where(Group.name == "group_managers"))
-    group = result.scalar_one()
+async def test_update_group_manager(
+    client: AsyncClient, manager_headers, manager_group, seeded_db
+):
+    group = manager_group
     group_id = group.id
 
     group_data = {
@@ -382,12 +358,9 @@ async def test_update_group_manager(client: AsyncClient, manager_headers, seeded
 
 @pytest.mark.asyncio
 async def test_update_group_whitespace_error(
-    client: AsyncClient, admin_headers, seeded_db
+    client: AsyncClient, admin_headers, admin_group, seeded_db
 ):
-    session = seeded_db
-
-    result = await session.execute(select(Group).where(Group.name == "group_admins"))
-    group = result.scalar_one()
+    group = admin_group
     group_id = group.id
 
     group_data = {
@@ -401,11 +374,8 @@ async def test_update_group_whitespace_error(
 
 
 @pytest.mark.asyncio
-async def test_update_group_requires_auth(client: AsyncClient, seeded_db):
-    session = seeded_db
-
-    result = await session.execute(select(Group).where(Group.name == "group_users"))
-    group = result.scalar_one()
+async def test_update_group_requires_auth(client: AsyncClient, user_group, seeded_db):
+    group = user_group
     group_id = group.id
 
     group_data = {
@@ -418,12 +388,9 @@ async def test_update_group_requires_auth(client: AsyncClient, seeded_db):
 
 @pytest.mark.asyncio
 async def test_update_group_insufficient_permission(
-    client: AsyncClient, user_headers, seeded_db
+    client: AsyncClient, user_headers, user_group, seeded_db
 ):
-    session = seeded_db
-
-    result = await session.execute(select(Group).where(Group.name == "group_users"))
-    group = result.scalar_one()
+    group = user_group
     group_id = group.id
 
     group_data = {
@@ -453,11 +420,10 @@ async def test_update_group_id_not_found(client: AsyncClient, admin_headers, see
 # Request: DELETE
 # Response: None
 @pytest.mark.asyncio
-async def test_delete_group_admin(client: AsyncClient, admin_headers, seeded_db):
-    session = seeded_db
-
-    result = await session.execute(select(Group).where(Group.name == "group_admins"))
-    group = result.scalar_one()
+async def test_delete_group_admin(
+    client: AsyncClient, admin_headers, admin_group, seeded_db
+):
+    group = admin_group
     group_id = group.id
 
     response = await client.delete(f"/api/groups/{group_id}", headers=admin_headers)
@@ -472,11 +438,10 @@ async def test_delete_group_admin(client: AsyncClient, admin_headers, seeded_db)
 
 
 @pytest.mark.asyncio
-async def test_delete_group_manager(client: AsyncClient, manager_headers, seeded_db):
-    session = seeded_db
-
-    result = await session.execute(select(Group).where(Group.name == "group_managers"))
-    group = result.scalar_one()
+async def test_delete_group_manager(
+    client: AsyncClient, manager_headers, manager_group, seeded_db
+):
+    group = manager_group
     group_id = group.id
 
     response = await client.delete(f"/api/groups/{group_id}", headers=manager_headers)
@@ -487,11 +452,8 @@ async def test_delete_group_manager(client: AsyncClient, manager_headers, seeded
 
 
 @pytest.mark.asyncio
-async def test_delete_group_requires_auth(client: AsyncClient, seeded_db):
-    session = seeded_db
-
-    result = await session.execute(select(Group).where(Group.name == "group_users"))
-    group = result.scalar_one()
+async def test_delete_group_requires_auth(client: AsyncClient, user_group, seeded_db):
+    group = user_group
     group_id = group.id
 
     response = await client.delete(f"/api/groups/{group_id}")
@@ -500,12 +462,9 @@ async def test_delete_group_requires_auth(client: AsyncClient, seeded_db):
 
 @pytest.mark.asyncio
 async def test_delete_group_insufficient_permission(
-    client: AsyncClient, user_headers, seeded_db
+    client: AsyncClient, user_headers, user_group, seeded_db
 ):
-    session = seeded_db
-
-    result = await session.execute(select(Group).where(Group.name == "group_users"))
-    group = result.scalar_one()
+    group = user_group
     group_id = group.id
 
     response = await client.delete(f"/api/groups/{group_id}", headers=user_headers)

--- a/backend/tests/routes/test_groups_helper.py
+++ b/backend/tests/routes/test_groups_helper.py
@@ -11,6 +11,7 @@ from models import Group, Role, User, UserGroup
 from server import app
 
 
+# Creates groups for users, managers, and admins
 @pytest.fixture(scope="function")
 async def seeded_db(test_db):
     TestSessionLocal = sessionmaker(
@@ -49,6 +50,7 @@ async def seeded_db(test_db):
         yield session
 
 
+# Creates admin user and adds them to the admin group
 @pytest.fixture
 async def admin_user_g(seeded_db):
     """Create an admin user for testing (roles already exist from test_db fixture)"""
@@ -92,6 +94,7 @@ async def admin_user_g(seeded_db):
     return admin_with_role
 
 
+# Creates admin headers
 @pytest.fixture
 async def admin_headers(client, admin_user_g, seeded_db):
     """Get authentication headers by overriding auth dependencies"""
@@ -114,6 +117,17 @@ async def admin_headers(client, admin_user_g, seeded_db):
     app.dependency_overrides.pop(require_admin, None)
 
 
+# Gets admin group
+@pytest.fixture
+async def admin_group(seeded_db):
+    session = seeded_db
+    result = await session.execute(select(Group).where(Group.name == "group_admins"))
+    group = result.scalar_one()
+
+    return group
+
+
+# Creates manager user and adds them to the manager group
 @pytest.fixture
 async def manager_user(seeded_db):
     """Create a manager user for testing (roles already exist from test_db fixture)"""
@@ -157,6 +171,7 @@ async def manager_user(seeded_db):
     return manager_with_role
 
 
+# Gets manager headers
 @pytest.fixture
 async def manager_headers(client, manager_user, seeded_db):
     """Get authentication headers by overriding auth dependencies"""
@@ -179,6 +194,17 @@ async def manager_headers(client, manager_user, seeded_db):
     app.dependency_overrides.pop(require_admin, None)
 
 
+# Gets manager group
+@pytest.fixture
+async def manager_group(seeded_db):
+    session = seeded_db
+    result = await session.execute(select(Group).where(Group.name == "group_managers"))
+    group = result.scalar_one()
+
+    return group
+
+
+# Creates normal user and adds them to the user group
 @pytest.fixture
 async def normal_user(seeded_db):
     """Create a normal user for testing (roles already exist from test_db fixture)"""
@@ -222,6 +248,7 @@ async def normal_user(seeded_db):
     return user_with_role
 
 
+# Gets user headers
 @pytest.fixture
 async def user_headers(client, normal_user, seeded_db):
     """Get authentication headers by overriding auth dependencies"""
@@ -237,3 +264,13 @@ async def user_headers(client, normal_user, seeded_db):
 
     # Clean up overrides after test
     app.dependency_overrides.pop(get_current_user, None)
+
+
+# Gets user group
+@pytest.fixture
+async def user_group(seeded_db):
+    session = seeded_db
+    result = await session.execute(select(Group).where(Group.name == "group_users"))
+    group = result.scalar_one()
+
+    return group


### PR DESCRIPTION
I cleaned the Group API tests in test_groups.py by moving the db select queries into fixtures. That way, the tests are not directly interacting with the db. I also added comments to the fixtures in test_groups_helper.py, explaining the role of each fixture.