### PR TITLE
 Refactor UI API helpers: extract shared client utilities and removes required API_URL argument

### DIFF
--- a/ui/src/components/groups/GroupMembers.tsx
+++ b/ui/src/components/groups/GroupMembers.tsx
@@ -77,7 +77,7 @@ export default function GroupMembers({
         setLoading(true);
         setError(null);
         try {
-            const updatedGroup = await getGroup(group.id, API_URL);
+            const updatedGroup = await getGroup(group.id);
             setMembers(updatedGroup.members || []);
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Unknown error');
@@ -99,7 +99,7 @@ export default function GroupMembers({
         setError(null);
 
         try {
-            await removeMemberFromGroup(group.id, userId, API_URL);
+            await removeMemberFromGroup(group.id, userId);
             await fetchMembers();
             if (onUpdate) onUpdate();
         } catch (err) {

--- a/ui/src/components/layout/UserSidebar.tsx
+++ b/ui/src/components/layout/UserSidebar.tsx
@@ -65,7 +65,7 @@ export default function UserSidebar({ contentOnly = false }: UserSidebarProps) {
     const navigate = useNavigate();
     const location = useLocation();
     const params = useParams();
-    const { userInfo, API_URL } = useAuth();
+    const { userInfo } = useAuth();
     const isUser = userInfo?.role?.name === 'user';
     const isAdmin = userInfo?.role?.name === 'admin';
     const isMobile = useMediaQuery('(max-width: 768px)');
@@ -105,12 +105,12 @@ export default function UserSidebar({ contentOnly = false }: UserSidebarProps) {
     }, [location.pathname]);
 
     const fetchCourseData = useCallback(async () => {
-        if (!courseId || !API_URL) return;
+        if (!courseId) return;
 
         setLoadingCourse(true);
         try {
             // Fetch course
-            const courseData = await getCourse(Number(courseId), API_URL);
+            const courseData = await getCourse(Number(courseId));
             setCourse(courseData);
             // Module functionality will be implemented by students
         } catch (err) {
@@ -118,16 +118,16 @@ export default function UserSidebar({ contentOnly = false }: UserSidebarProps) {
         } finally {
             setLoadingCourse(false);
         }
-    }, [courseId, API_URL]);
+    }, [courseId]);
 
     // Fetch course data when on course pages
     useEffect(() => {
-        if (showCourseNav && courseId && API_URL) {
+        if (showCourseNav && courseId) {
             fetchCourseData();
         } else {
             setCourse(null);
         }
-    }, [showCourseNav, courseId, fetchCourseData, API_URL]);
+    }, [showCourseNav, courseId, fetchCourseData]);
 
     // NOW we can do early returns - all hooks have been called
     // Desktop: Show sidebar if user is a regular user OR if on preview route

--- a/ui/src/components/users/UserGroupsAndCourses.tsx
+++ b/ui/src/components/users/UserGroupsAndCourses.tsx
@@ -47,13 +47,7 @@ interface CourseProgress {
     percentage: number;
 }
 
-interface UserGroupsAndCoursesProps {
-    API_URL: string;
-}
-
-export default function UserGroupsAndCourses({
-    API_URL,
-}: UserGroupsAndCoursesProps) {
+export default function UserGroupsAndCourses() {
     const navigate = useNavigate();
     const { userInfo } = useAuth();
     const [groups, setGroups] = useState<ApiGroup[]>([]);
@@ -74,7 +68,7 @@ export default function UserGroupsAndCourses({
         setError(null);
         try {
             // Fetch user's groups (backend filters to only groups user is a member of)
-            const groupsData = await getGroups(API_URL);
+            const groupsData = await getGroups();
 
             // Verify each group is accessible (defensive check)
             // The backend should already filter correctly, but we verify to be safe
@@ -82,7 +76,7 @@ export default function UserGroupsAndCourses({
             for (const group of groupsData) {
                 try {
                     // Try to access the group details - this will fail with 403 if user doesn't have access
-                    await getGroup(group.id, API_URL);
+                    await getGroup(group.id);
                     verifiedGroups.push(group);
                 } catch (err) {
                     // If we can't access this group, skip it and log a warning
@@ -99,10 +93,7 @@ export default function UserGroupsAndCourses({
             const courseGroupsData: CourseGroup[] = [];
             for (const group of verifiedGroups) {
                 try {
-                    const groupCourses = await getGroupCourses(
-                        group.id,
-                        API_URL
-                    );
+                    const groupCourses = await getGroupCourses(group.id);
                     groupCourses.forEach((course) => {
                         courseGroupsData.push({
                             course_id: course.id,
@@ -126,7 +117,7 @@ export default function UserGroupsAndCourses({
             );
 
             // Fetch all courses and filter to only accessible ones
-            const allCourses = await getCourses(API_URL);
+            const allCourses = await getCourses();
             const accessibleCourses = allCourses.filter((course) =>
                 accessibleCourseIds.has(course.id)
             );

--- a/ui/src/pages/courses/CourseDetailPage.tsx
+++ b/ui/src/pages/courses/CourseDetailPage.tsx
@@ -11,7 +11,7 @@ import type { CourseUpdate, CourseDetail } from '../../types/api';
 
 export default function CourseDetailPage() {
     const { courseId } = useParams<{ courseId: string }>();
-    const { API_URL, userInfo } = useAuth();
+    const { userInfo } = useAuth();
     const [editModalOpened, { open: openEditModal, close: closeEditModal }] =
         useDisclosure(false);
 
@@ -30,7 +30,7 @@ export default function CourseDetailPage() {
         setLoading(true);
         setError(null);
         try {
-            const courseData = await getCourse(Number(courseId), API_URL);
+            const courseData = await getCourse(Number(courseId));
             setCourse(courseData);
         } catch (err) {
             const errorMessage =
@@ -76,7 +76,7 @@ export default function CourseDetailPage() {
                 description: courseDescription.trim() || null,
             };
 
-            await patchCourse(Number(courseId), updateData, API_URL);
+            await patchCourse(Number(courseId), updateData);
             closeEditModal();
             await fetchCourse();
         } catch (err) {

--- a/ui/src/pages/courses/CoursesPage.tsx
+++ b/ui/src/pages/courses/CoursesPage.tsx
@@ -16,7 +16,6 @@ import {
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { IconPlus, IconBook } from '@tabler/icons-react';
-import { useAuth } from '../../contexts/AuthContext';
 import { getCourses, createCourse } from '../../utils/api';
 import { useViewMode } from '../../hooks/useViewMode';
 import { useTableSort } from '../../hooks/useTableSort';
@@ -27,7 +26,6 @@ import AdminPageLayout from '../../components/layout/AdminPageLayout';
 import type { Course, CourseCreate } from '../../types/api';
 
 export default function CoursesPage() {
-    const { API_URL } = useAuth();
     const navigate = useNavigate();
 
     const [courses, setCourses] = useState<Course[]>([]);
@@ -59,7 +57,7 @@ export default function CoursesPage() {
         setLoading(true);
         setError(null);
         try {
-            const data = await getCourses(API_URL);
+            const data = await getCourses();
             setCourses(data);
         } catch (err) {
             const errorMessage =
@@ -84,7 +82,7 @@ export default function CoursesPage() {
             // File upload functionality will be implemented by students
 
             // Create the course
-            await createCourse(courseData, API_URL);
+            await createCourse(courseData);
             setCourseTitle('');
             setCourseDescription('');
             closeCreateModal();

--- a/ui/src/pages/groups/GroupDetailPage.tsx
+++ b/ui/src/pages/groups/GroupDetailPage.tsx
@@ -89,7 +89,7 @@ export default function GroupDetailPage() {
         setLoading(true);
         setError(null);
         try {
-            const groupData = await getGroup(Number(groupId), API_URL);
+            const groupData = await getGroup(Number(groupId));
             setGroup(groupData);
             // Initialize form state
             setGroupName(groupData.name);
@@ -110,7 +110,7 @@ export default function GroupDetailPage() {
         if (!groupId) return;
         setCoursesLoading(true);
         try {
-            const data = await getGroupCourses(Number(groupId), API_URL);
+            const data = await getGroupCourses(Number(groupId));
             setCourses(data);
         } catch (err) {
             console.error('Error fetching group courses:', err);
@@ -140,7 +140,7 @@ export default function GroupDetailPage() {
                 name: groupName.trim(),
                 description: groupDescription.trim() || null,
             };
-            await patchGroup(Number(groupId), updateData, API_URL);
+            await patchGroup(Number(groupId), updateData);
             closeEditModal();
             // Refresh group data
             await fetchGroup();

--- a/ui/src/pages/groups/GroupsPage.tsx
+++ b/ui/src/pages/groups/GroupsPage.tsx
@@ -15,7 +15,6 @@ import {
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { IconPlus, IconBook } from '@tabler/icons-react';
-import { useAuth } from '../../contexts/AuthContext';
 import { getGroups, createGroup } from '../../utils/api';
 // InviteUser component removed - students will implement invite system
 import { useViewMode } from '../../hooks/useViewMode';
@@ -33,7 +32,6 @@ interface GroupWithCourses extends GroupType {
 }
 
 export default function GroupsPage() {
-    const { API_URL } = useAuth();
     const navigate = useNavigate();
 
     const [groups, setGroups] = useState<GroupWithCourses[]>([]);
@@ -75,7 +73,7 @@ export default function GroupsPage() {
         setLoading(true);
         setError(null);
         try {
-            const data = await getGroups(API_URL);
+            const data = await getGroups();
 
             // Course assignment will be implemented by students
             const groupsWithCourses = data.map((group) => ({
@@ -103,13 +101,10 @@ export default function GroupsPage() {
         setError(null);
 
         try {
-            await createGroup(
-                {
-                    name: groupName.trim(),
-                    description: groupDescription.trim() || null,
-                },
-                API_URL
-            );
+            await createGroup({
+                name: groupName.trim(),
+                description: groupDescription.trim() || null,
+            });
             setGroupName('');
             setGroupDescription('');
             closeCreateModal();

--- a/ui/src/pages/users/CreateUserPage.tsx
+++ b/ui/src/pages/users/CreateUserPage.tsx
@@ -13,14 +13,12 @@ import {
     Divider,
     Grid,
 } from '@mantine/core';
-import { useAuth } from '../../contexts/AuthContext';
 import { createUser } from '../../utils/api';
 import AdminPageLayout from '../../components/layout/AdminPageLayout';
 import type { UserCreate } from '../../types/api';
 
 export default function CreateUserPage() {
     const navigate = useNavigate();
-    const { API_URL } = useAuth();
     const [saving, setSaving] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
@@ -55,7 +53,7 @@ export default function CreateUserPage() {
                 child_dob: childDob || null,
             };
 
-            await createUser(userData, API_URL);
+            await createUser(userData);
             // Navigate back to users list
             navigate('/dashboard/users');
         } catch (err) {

--- a/ui/src/pages/users/EditUserPage.tsx
+++ b/ui/src/pages/users/EditUserPage.tsx
@@ -94,7 +94,7 @@ export default function EditUserPage() {
 
     async function fetchGroups() {
         try {
-            const groups = await getGroups(API_URL);
+            const groups = await getGroups();
             setAllGroups(groups);
         } catch (err) {
             console.error('Failed to fetch groups:', err);
@@ -107,8 +107,8 @@ export default function EditUserPage() {
         setError(null);
         try {
             const [users, groups] = await Promise.all([
-                getAllUsers(API_URL),
-                getGroups(API_URL),
+                getAllUsers(),
+                getGroups(),
             ]);
 
             const foundUser = users.find((u) => u.id === parseInt(userId));
@@ -142,7 +142,7 @@ export default function EditUserPage() {
             const userGroupIds: string[] = [];
             for (const group of groups) {
                 try {
-                    const groupDetail = await getGroup(group.id, API_URL);
+                    const groupDetail = await getGroup(group.id);
                     if (groupDetail.members) {
                         const isMember = groupDetail.members.some(
                             (m) => m.user_id === foundUser.id
@@ -294,12 +294,12 @@ export default function EditUserPage() {
         try {
             // Update role if changed
             if (role !== user.role?.name) {
-                await updateUserRole(user.id, role, API_URL);
+                await updateUserRole(user.id, role);
             }
 
             // Update status if changed
             if (isActive !== user.is_active) {
-                await updateUserStatus(user.id, isActive, API_URL);
+                await updateUserStatus(user.id, isActive);
             }
 
             // Update profile fields
@@ -311,7 +311,7 @@ export default function EditUserPage() {
                 child_dob: childDob || null,
                 avatar_url: avatarUrl || null,
             };
-            await updateUserProfile(user.id, profileData, API_URL);
+            await updateUserProfile(user.id, profileData);
 
             // Update group memberships
             const groupsToAdd = selectedGroups.filter(
@@ -327,8 +327,7 @@ export default function EditUserPage() {
                     await addMemberToGroup(
                         parseInt(groupId),
                         user.id,
-                        'member',
-                        API_URL
+                        'member'
                     );
                 } catch (err) {
                     console.error(
@@ -341,11 +340,7 @@ export default function EditUserPage() {
             // Remove user from groups
             for (const groupId of groupsToRemove) {
                 try {
-                    await removeMemberFromGroup(
-                        parseInt(groupId),
-                        user.id,
-                        API_URL
-                    );
+                    await removeMemberFromGroup(parseInt(groupId), user.id);
                 } catch (err) {
                     console.error(
                         `Failed to remove user from group ${groupId}:`,
@@ -373,7 +368,7 @@ export default function EditUserPage() {
 
         try {
             // First disable the user
-            await updateUserStatus(user.id, false, API_URL);
+            await updateUserStatus(user.id, false);
             // TODO: Add delete user endpoint when backend supports it
             // For now, we'll just disable the user
             setError(

--- a/ui/src/pages/users/UserCoursesPage.tsx
+++ b/ui/src/pages/users/UserCoursesPage.tsx
@@ -1,6 +1,5 @@
 import { Stack, Text, Alert, Card, SimpleGrid } from '@mantine/core';
 import { IconBook } from '@tabler/icons-react';
-import { useAuth } from '../../contexts/AuthContext';
 import { getCourses } from '../../utils/api';
 import { useState, useEffect } from 'react';
 import LoadingSpinner from '../../components/ui/LoadingSpinner';
@@ -8,7 +7,6 @@ import UserPageLayout from '../../components/layout/UserPageLayout';
 import type { Course } from '../../types/api';
 
 export default function UserCoursesPage() {
-    const { API_URL } = useAuth();
     const [courses, setCourses] = useState<Course[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -23,7 +21,7 @@ export default function UserCoursesPage() {
         setError(null);
         try {
             // Fetch user's courses (filtered by groups)
-            const coursesData = await getCourses(API_URL);
+            const coursesData = await getCourses();
             setCourses(coursesData);
         } catch (err) {
             const errorMessage =

--- a/ui/src/pages/users/UserGroupDetailPage.tsx
+++ b/ui/src/pages/users/UserGroupDetailPage.tsx
@@ -12,7 +12,6 @@ import {
     SimpleGrid,
 } from '@mantine/core';
 import { IconUsersGroup, IconUser } from '@tabler/icons-react';
-import { useAuth } from '../../contexts/AuthContext';
 import { useViewMode } from '../../hooks/useViewMode';
 import { getGroup } from '../../utils/api';
 import { formatLastActive } from '../../utils/dateUtils';
@@ -46,7 +45,6 @@ function getRoleBadgeColor(role: string | undefined): string {
 
 export default function UserGroupDetailPage() {
     const { groupId } = useParams<{ groupId: string }>();
-    const { API_URL } = useAuth();
     const [viewMode] = useViewMode();
     const [group, setGroup] = useState<GroupDetail | null>(null);
     const [loading, setLoading] = useState(true);
@@ -64,7 +62,7 @@ export default function UserGroupDetailPage() {
         setLoading(true);
         setError(null);
         try {
-            const groupData = await getGroup(Number(groupId), API_URL);
+            const groupData = await getGroup(Number(groupId));
             setGroup(groupData);
         } catch (err) {
             const errorMessage =

--- a/ui/src/pages/users/UserGroupsPage.tsx
+++ b/ui/src/pages/users/UserGroupsPage.tsx
@@ -10,7 +10,6 @@ import {
     Alert,
 } from '@mantine/core';
 import { IconUsersGroup } from '@tabler/icons-react';
-import { useAuth } from '../../contexts/AuthContext';
 import { getGroups, getGroup } from '../../utils/api';
 import LoadingSpinner from '../../components/ui/LoadingSpinner';
 import UserPageLayout from '../../components/layout/UserPageLayout';
@@ -22,7 +21,6 @@ interface GroupWithMemberCount extends GroupType {
 
 export default function UserGroupsPage() {
     const navigate = useNavigate();
-    const { API_URL } = useAuth();
     const [groups, setGroups] = useState<GroupWithMemberCount[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -37,13 +35,13 @@ export default function UserGroupsPage() {
         setError(null);
         try {
             // Fetch user's groups
-            const groupsData = await getGroups(API_URL);
+            const groupsData = await getGroups();
 
             // Verify each group is accessible
             const verifiedGroups: GroupWithMemberCount[] = [];
             for (const group of groupsData) {
                 try {
-                    const groupDetail = await getGroup(group.id, API_URL);
+                    const groupDetail = await getGroup(group.id);
                     verifiedGroups.push({
                         ...group,
                         member_count: groupDetail.members?.length || 0,

--- a/ui/src/pages/users/UsersPage.tsx
+++ b/ui/src/pages/users/UsersPage.tsx
@@ -40,13 +40,13 @@ export default function UsersPage() {
         setError(null);
         try {
             const [usersData, groupsData] = await Promise.all([
-                getAllUsers(API_URL),
-                getGroups(API_URL),
+                getAllUsers(),
+                getGroups(),
             ]);
             setUsers(usersData);
 
             // Build user groups mapping
-            const userGroupsMap = await buildUserGroupsMap(groupsData, API_URL);
+            const userGroupsMap = await buildUserGroupsMap(groupsData);
             setUserGroups(userGroupsMap);
         } catch (err) {
             const errorMessage =

--- a/ui/src/utils/api.ts
+++ b/ui/src/utils/api.ts
@@ -2,6 +2,7 @@
  * API utility functions for making authenticated requests
  */
 
+import { getApiUrl, getAuthHeaders, handleResponse } from './apiClient';
 import type {
     User,
     UserCreate,
@@ -16,96 +17,8 @@ import type {
     CourseUpdate,
 } from '../types/api.js';
 
-/**
- * Get authentication headers for API requests
- * @param includeContentType - Whether to include Content-Type header (default: true)
- * @returns Headers object with Content-Type (if requested) and Authorization
- */
-export function getAuthHeaders(
-    includeContentType = true
-): Record<string, string> {
-    const token = localStorage.getItem('auth_token');
-    const headers: Record<string, string> = {
-        ...(includeContentType && { 'Content-Type': 'application/json' }),
-        ...(token && { Authorization: `Bearer ${token}` }),
-    };
-
-    return headers;
-}
-
-/**
- * Get the API base URL from environment or default to localhost
- * Includes /api prefix for all API routes
- */
-export function getApiUrl(): string {
-    const baseUrl =
-        (import.meta.env.VITE_API_URL as string | undefined) !== undefined
-            ? (import.meta.env.VITE_API_URL as string)
-            : 'http://localhost:8000';
-    // Ensure /api is appended to the base URL
-    return baseUrl.endsWith('/api') ? baseUrl : `${baseUrl}/api`;
-}
-
-interface ErrorResponse {
-    detail?: string;
-}
-
-/**
- * Handle API response errors consistently
- * @param response - Fetch response object
- * @returns Parsed JSON response
- * @throws {Error} If response is not ok
- */
-async function handleResponse<T = unknown>(
-    response: Response
-): Promise<T | null> {
-    if (!response.ok) {
-        let errorMessage = `Server error: ${response.status} ${response.statusText}`;
-        try {
-            const errorData = (await response.json()) as ErrorResponse;
-            errorMessage = errorData.detail || errorMessage;
-        } catch {
-            // If response is not JSON, use status text
-        }
-
-        // Log more details for debugging
-        if (response.status === 401 || response.status === 403) {
-            console.error('Authentication error:', {
-                status: response.status,
-                statusText: response.statusText,
-                message: errorMessage,
-                hasToken: !!localStorage.getItem('auth_token'),
-            });
-        }
-
-        // Check for authentication errors and redirect to login
-        if (
-            response.status === 401 ||
-            response.status === 403 ||
-            errorMessage.includes('Could not validate credentials') ||
-            errorMessage.includes('Not authenticated')
-        ) {
-            // Clear auth token
-            localStorage.removeItem('auth_token');
-            localStorage.removeItem('token_type');
-
-            // Redirect to login page
-            // Only redirect if we're not already on the login page
-            if (window.location.pathname !== '/login') {
-                window.location.href = '/login';
-            }
-        }
-
-        throw new Error(errorMessage);
-    }
-
-    // Handle 204 No Content responses (common for DELETE requests)
-    if (response.status === 204) {
-        return null;
-    }
-
-    return response.json() as Promise<T>;
-}
+// Re-export these so existing imports from '../utils/api' keep working.
+export { getApiUrl, getAuthHeaders };
 
 // ============================================================================
 // USER API Functions

--- a/ui/src/utils/apiClient.ts
+++ b/ui/src/utils/apiClient.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared API client helpers (non-React).
+ *
+ * Keep this file free of React/context so it can be used from:
+ * - UI pages/components (via higher-level helpers in utils/api.ts)
+ * - AuthContext (auth checks)
+ * - Any future split-out API modules (coursesApi.ts, modulesApi.ts, etc.)
+ */
+
+/**
+ * Get authentication headers for API requests.
+ * Reads bearer token from localStorage.
+ */
+export function getAuthHeaders(
+    includeContentType = true
+): Record<string, string> {
+    const token = localStorage.getItem('auth_token');
+    const headers: Record<string, string> = {
+        ...(includeContentType && { 'Content-Type': 'application/json' }),
+        ...(token && { Authorization: `Bearer ${token}` }),
+    };
+
+    return headers;
+}
+
+/**
+ * Get the API base URL from environment or default to localhost.
+ * Includes /api prefix for all API routes.
+ */
+export function getApiUrl(): string {
+    const baseUrl =
+        (import.meta.env.VITE_API_URL as string | undefined) !== undefined
+            ? (import.meta.env.VITE_API_URL as string)
+            : 'http://localhost:8000';
+    // Ensure /api is appended to the base URL
+    return baseUrl.endsWith('/api') ? baseUrl : `${baseUrl}/api`;
+}
+
+interface ErrorResponse {
+    detail?: string;
+}
+
+/**
+ * Handle API response errors consistently.
+ * @returns Parsed JSON response, or null for 204 responses
+ * @throws {Error} If response is not ok
+ */
+export async function handleResponse<T = unknown>(
+    response: Response
+): Promise<T | null> {
+    if (!response.ok) {
+        let errorMessage = `Server error: ${response.status} ${response.statusText}`;
+        try {
+            const errorData = (await response.json()) as ErrorResponse;
+            errorMessage = errorData.detail || errorMessage;
+        } catch {
+            // If response is not JSON, use status text
+        }
+
+        // Log more details for debugging
+        if (response.status === 401 || response.status === 403) {
+            console.error('Authentication error:', {
+                status: response.status,
+                statusText: response.statusText,
+                message: errorMessage,
+                hasToken: !!localStorage.getItem('auth_token'),
+            });
+        }
+
+        // Check for authentication errors and redirect to login
+        if (
+            response.status === 401 ||
+            response.status === 403 ||
+            errorMessage.includes('Could not validate credentials') ||
+            errorMessage.includes('Not authenticated')
+        ) {
+            // Clear auth token
+            localStorage.removeItem('auth_token');
+            localStorage.removeItem('token_type');
+
+            // Redirect to login page
+            // Only redirect if we're not already on the login page
+            if (window.location.pathname !== '/login') {
+                window.location.href = '/login';
+            }
+        }
+
+        throw new Error(errorMessage);
+    }
+
+    // Handle 204 No Content responses (common for DELETE requests)
+    if (response.status === 204) {
+        return null;
+    }
+
+    return response.json() as Promise<T>;
+}

--- a/ui/src/utils/userUtils.ts
+++ b/ui/src/utils/userUtils.ts
@@ -4,6 +4,8 @@
  * @param apiUrl - Base API URL
  * @returns Full avatar URL or null
  */
+import { getApiUrl } from './apiClient';
+
 export function getAvatarUrl(
     avatarUrl: string | null | undefined,
     apiUrl: string
@@ -52,7 +54,7 @@ export function getRoleBadgeColor(roleName: string): string {
  */
 export async function buildUserGroupsMap(
     groups: Array<{ id: number; name: string }>,
-    apiUrl: string
+    apiUrl = getApiUrl()
 ): Promise<Record<number, string[]>> {
     const { getGroup } = await import('./api');
     const userGroupsMap: Record<number, string[]> = {};


### PR DESCRIPTION
## What changed
* Extracted shared API client helpers into `ui/src/utils/apiClient.ts`: `getApiUrl()`, `getAuthHeaders()`, `handleResponse()`
* Updated `ui/src/utils/api.ts` to use `apiClient` internally and re-export `getApiUrl`/`getAuthHeaders` to avoid breaking existing imports.
* Simplified page/component call sites to stop passing `API_URL` into API helpers (they already default to getApiUrl()), while still allowing an override via optional apiUrl params.

## Why
* Centralizes API base URL + auth header logic in one non-React place.
* Reduces parameter noise across pages while keeping override hooks for tests/special cases.
* Makes it easier to split api.ts into domain files later (courses.ts, modules.ts, etc.).

## Notes
* No behavior change intended; this is an organizational/cleanup refactor.
