### PR TITLE
Added Post type definitions and Post Dummy Data

### DIFF
--- a/mobile/types/api.ts
+++ b/mobile/types/api.ts
@@ -134,4 +134,53 @@ export interface CourseGroup {
     date_assigned: string;
 }
 
-// Module, Post, Quiz, and Progress types removed - these will be implemented by students
+// ============================================================================
+// Post Types
+// ============================================================================
+interface PostBase {
+    id: number;
+    title: string;
+    type: 'generic' | 'attachment' | 'video' | 'quiz';
+    text: string;
+}
+
+export interface PostAttachmentType extends PostBase {
+    pdfUrl: string;
+    fileName: string;
+    fileSize: number;
+}
+
+export interface PostGeneric extends PostBase {
+    image?: string;
+}
+
+export interface PostVideo extends PostBase {
+    vimeoId: string;
+}
+
+export interface PostQuiz extends PostBase {
+    questions: (
+        | MultipleChoiceQuestion
+        | TrueFalseQuestion
+        | SelectAllQuestion
+    )[];
+}
+
+interface QuestionBase {
+    question: string;
+    type: string;
+}
+
+export interface MultipleChoiceQuestion extends QuestionBase {
+    options: string[];
+    validAnswers: number[];
+}
+
+export interface TrueFalseQuestion extends QuestionBase {
+    validAnswers: boolean[];
+}
+
+export interface SelectAllQuestion extends QuestionBase {
+    options: string[];
+    validAnswers: number[];
+}

--- a/mobile/utils/dummyPost.ts
+++ b/mobile/utils/dummyPost.ts
@@ -1,0 +1,61 @@
+import { PostAttachmentType, PostGeneric, PostQuiz, PostVideo } from '../types';
+
+export const dummyPosts: (
+    | PostGeneric
+    | PostAttachmentType
+    | PostVideo
+    | PostQuiz
+)[] = [
+    {
+        id: 1,
+        title: 'Introduction to React Native',
+        type: 'generic',
+        text: 'React Native is a framework for building mobile apps...',
+        image: 'https://example.com/image.jpg', // optional
+    },
+    {
+        id: 2,
+        title: 'Course Syllabus PDF',
+        type: 'attachment',
+        text: 'Download the course syllabus here.',
+        pdfUrl: 'https://example.com/syllabus.pdf',
+        fileName: 'syllabus.pdf',
+        fileSize: 1024000,
+    },
+    {
+        id: 3,
+        title: 'React Native Tutorial Video',
+        type: 'video',
+        text: 'Watch this video to learn React Native basics.',
+        vimeoId: '123456789', // or vimeoUrl
+    },
+    {
+        id: 4,
+        title: 'Week 1 Quiz',
+        type: 'quiz',
+        text: 'Test your knowledge with this quiz.',
+        questions: [
+            {
+                question: 'What is React Native?',
+                type: 'multiple_choice',
+                options: [
+                    'A web framework',
+                    'A mobile framework',
+                    'A database',
+                ],
+                validAnswers: [1], // index of correct answer
+            },
+            {
+                question: 'React Native uses JavaScript.',
+                type: 'true_false',
+                validAnswers: [true],
+            },
+            {
+                question: 'Which are React Native features?',
+                type: 'select_all',
+                options: ['Cross-platform', 'Hot reload', 'Native performance'],
+                validAnswers: [0, 1, 2], // all are correct
+            },
+        ],
+    },
+];


### PR DESCRIPTION
While I was working, I found it convenient to actually develop all the Post types so that I could properly define the dummy data. The Post types extend a shared parent interface containing the data they have in common. 

The dummy data is an array containing potentially each of the types. Here is an example use case of one of the items, where I personally assert the specific type of post that it is:
 `const attachmentPostData: PostAttachmentType = dummyPosts[1] as PostAttachmentType;`
 
 You have to use the `as PostXYZType` because TypeScript is unsure which of the different Post types it may be. You can verify a post's type by checking the value of `type` which every post type has. `type` has the following potential values: 
  ` 'generic' | 'attachment' | 'video' | 'quiz'`.
  
  **Note**: I found it easier to add 'Type' to the back of the types name to differentiate it from the component, which previously shared the name `PostAttachment`. This does slightly break the naming convention of the types in `api.ts`, but without it, I was getting import conflicts when importing both the type and the component in the same place.