### PR TITLE
PostAttachment Component (Person 3):

### DIFF
--- a/mobile/app/(tabs)/progress.tsx
+++ b/mobile/app/(tabs)/progress.tsx
@@ -3,9 +3,14 @@ import { Card, Text, Appbar, useTheme } from 'react-native-paper';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import ProtectedRoute from '../../components/ProtectedRoute';
 import { designTokens } from '../../theme';
+import PostAttachment from '../../components/posts/PostAttachment';
+import { dummyPosts } from '../../utils/dummyPost';
+import { PostAttachmentType } from '../../types';
 
 export default function ProgressScreen() {
     const theme = useTheme();
+    const attachmentPostData: PostAttachmentType =
+        dummyPosts[1] as PostAttachmentType;
 
     return (
         <ProtectedRoute>
@@ -46,6 +51,7 @@ export default function ProgressScreen() {
                         </Card.Content>
                     </Card>
                 </ScrollView>
+                <PostAttachment postInfo={attachmentPostData} />
             </View>
         </ProtectedRoute>
     );

--- a/mobile/app/(tabs)/progress.tsx
+++ b/mobile/app/(tabs)/progress.tsx
@@ -3,14 +3,9 @@ import { Card, Text, Appbar, useTheme } from 'react-native-paper';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import ProtectedRoute from '../../components/ProtectedRoute';
 import { designTokens } from '../../theme';
-import PostAttachment from '../../components/posts/PostAttachment';
-import { dummyPosts } from '../../utils/dummyPost';
-import { PostAttachmentType } from '../../types';
 
 export default function ProgressScreen() {
     const theme = useTheme();
-    const attachmentPostData: PostAttachmentType =
-        dummyPosts[1] as PostAttachmentType;
 
     return (
         <ProtectedRoute>
@@ -51,7 +46,6 @@ export default function ProgressScreen() {
                         </Card.Content>
                     </Card>
                 </ScrollView>
-                <PostAttachment postInfo={attachmentPostData} />
             </View>
         </ProtectedRoute>
     );

--- a/mobile/components/posts/PostAttachment.tsx
+++ b/mobile/components/posts/PostAttachment.tsx
@@ -1,0 +1,133 @@
+import { View, StyleSheet, ScrollView, Pressable } from 'react-native';
+import { PostAttachmentType } from '../../types';
+import theme, { designTokens } from '../../theme';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { Appbar, Card, Text } from 'react-native-paper';
+
+interface props {
+    postInfo: PostAttachmentType;
+}
+export default function PostAttachment({ postInfo }: props) {
+    function handleDownload() {
+        console.log('Eventually handle download');
+    }
+
+    // TODO: Add imagined behavior for download button
+    // Ex. disabled during download, on press color change behavior?
+
+    function generateReadableFileSize() {
+        // File sizes are in bytes originally, ex. 1024000
+        const fileSizeBites = postInfo.fileSize;
+
+        // bytes to kilobytes
+        const fileSizeKB: number = fileSizeBites / 1000;
+
+        const fileSizeMB: number = fileSizeKB / 1000;
+        if (fileSizeMB < 1) return fileSizeKB.toFixed(3) + ' KB';
+
+        const fileSizeGB: number = fileSizeMB / 1000;
+        if (fileSizeGB < 1) return fileSizeMB.toFixed(3) + ' MB';
+
+        const fileSizeTB: number = fileSizeGB / 1000;
+        if (fileSizeTB < 1) return fileSizeGB.toFixed(3) + ' GB';
+        return fileSizeTB.toFixed(3) + ' TB';
+    }
+
+    return (
+        <View
+            style={[
+                styles.container,
+                { backgroundColor: theme.colors.background },
+            ]}
+        >
+            <Appbar.Header elevated>
+                <Appbar.Content
+                    title={postInfo.title}
+                    titleStyle={styles.headerTitle}
+                />
+            </Appbar.Header>
+
+            <ScrollView
+                style={styles.scrollView}
+                contentContainerStyle={styles.scrollContent}
+            >
+                <Text style={styles.postText}>{postInfo.text}</Text>
+                <Card style={styles.emptyCard} mode="elevated">
+                    <Pressable onPress={handleDownload}>
+                        <Card.Content style={styles.emptyContent}>
+                            <MaterialCommunityIcons
+                                name="download"
+                                size={64}
+                                color={theme.colors.onSurfaceVariant}
+                                style={styles.emptyIcon}
+                            />
+                            <View style={styles.cardTextContent}>
+                                <Text
+                                    variant="titleLarge"
+                                    style={styles.emptyTitle}
+                                >
+                                    Download PDF
+                                </Text>
+                                <Text
+                                    variant="bodyMedium"
+                                    style={styles.emptyText}
+                                >
+                                    {postInfo.fileName}
+                                    {'\t'}
+                                    {generateReadableFileSize()}
+                                </Text>
+                            </View>
+                        </Card.Content>
+                    </Pressable>
+                </Card>
+            </ScrollView>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+    },
+    scrollView: {
+        flex: 1,
+    },
+    scrollContent: {
+        padding: designTokens.spacing.xl,
+        paddingBottom: designTokens.spacing.xxxl,
+    },
+    headerTitle: {
+        fontWeight: '600',
+        fontSize: 20,
+    },
+    emptyCard: {
+        marginTop: designTokens.spacing.xxl,
+        borderRadius: designTokens.borderRadius.lg,
+    },
+    emptyContent: {
+        padding: designTokens.spacing.xxxl,
+        flex: 1,
+        flexDirection: 'row',
+        justifyContent: 'center',
+        gap: 24, // alignItems: 'center',
+    },
+    emptyIcon: {
+        // marginBottom: designTokens.spacing.lg,
+        opacity: 0.5,
+    },
+    emptyTitle: {
+        marginBottom: designTokens.spacing.sm,
+        fontWeight: '600',
+    },
+    emptyText: {
+        textAlign: 'left',
+        opacity: 0.7,
+    },
+    cardTextContent: {
+        flex: 1,
+        justifyContent: 'center',
+    },
+    postText: {
+        textAlign: 'center',
+    },
+});

--- a/mobile/components/posts/PostAttachment.tsx
+++ b/mobile/components/posts/PostAttachment.tsx
@@ -1,37 +1,51 @@
-import { View, StyleSheet, ScrollView, Pressable } from 'react-native';
+import {
+    View,
+    StyleSheet,
+    ScrollView,
+    Linking,
+    useWindowDimensions,
+} from 'react-native';
 import { PostAttachmentType } from '../../types';
 import theme, { designTokens } from '../../theme';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
-import { Appbar, Card, Text } from 'react-native-paper';
+import { Appbar, Card, Text, Button } from 'react-native-paper';
+import { useState } from 'react';
+import generateReadableFileSize from '../../utils/generateReadableFileSize';
 
 interface props {
     postInfo: PostAttachmentType;
 }
 export default function PostAttachment({ postInfo }: props) {
+    const { width } = useWindowDimensions();
+    const [isDownloading, setIsDownloading] = useState<boolean>(false);
+    // ^ Later used to disable download button while downloading
+
     function handleDownload() {
         console.log('Eventually handle download');
+
+        // Dummy code showing that download button can disable during download
+        setIsDownloading(true);
+        setTimeout(() => {
+            setIsDownloading(false);
+        }, 2000);
     }
 
-    // TODO: Add imagined behavior for download button
-    // Ex. disabled during download, on press color change behavior?
+    const openWebsite = () => {
+        Linking.openURL(postInfo.pdfUrl);
+    };
 
-    function generateReadableFileSize() {
-        // File sizes are in bytes originally, ex. 1024000
-        const fileSizeBites = postInfo.fileSize;
+    // Used to change the layout a bit on larger screens
+    const responsiveStyle = StyleSheet.create({
+        flexContainer: {
+            flex: 1,
+            flexDirection: width > 600 ? 'row' : 'column',
+            justifyContent: 'space-between',
+        },
 
-        // bytes to kilobytes
-        const fileSizeKB: number = fileSizeBites / 1000;
-
-        const fileSizeMB: number = fileSizeKB / 1000;
-        if (fileSizeMB < 1) return fileSizeKB.toFixed(3) + ' KB';
-
-        const fileSizeGB: number = fileSizeMB / 1000;
-        if (fileSizeGB < 1) return fileSizeMB.toFixed(3) + ' MB';
-
-        const fileSizeTB: number = fileSizeGB / 1000;
-        if (fileSizeTB < 1) return fileSizeGB.toFixed(3) + ' GB';
-        return fileSizeTB.toFixed(3) + ' TB';
-    }
+        cardWidth: {
+            width: width > 600 ? '47%' : 'auto',
+        },
+    });
 
     return (
         <View
@@ -52,8 +66,23 @@ export default function PostAttachment({ postInfo }: props) {
                 contentContainerStyle={styles.scrollContent}
             >
                 <Text style={styles.postText}>{postInfo.text}</Text>
-                <Card style={styles.emptyCard} mode="elevated">
-                    <Pressable onPress={handleDownload}>
+                <View style={responsiveStyle.flexContainer}>
+                    <Button
+                        icon="link-variant"
+                        mode="elevated"
+                        onPress={openWebsite}
+                        style={[styles.emptyCard, responsiveStyle.cardWidth]}
+                    >
+                        {postInfo.pdfUrl}
+                    </Button>
+
+                    {/* <Card style={styles.emptyCard} mode="elevated"> */}
+                    <Button
+                        mode="elevated"
+                        onPress={handleDownload}
+                        disabled={isDownloading}
+                        style={[styles.emptyCard, responsiveStyle.cardWidth]}
+                    >
                         <Card.Content style={styles.emptyContent}>
                             <MaterialCommunityIcons
                                 name="download"
@@ -73,13 +102,15 @@ export default function PostAttachment({ postInfo }: props) {
                                     style={styles.emptyText}
                                 >
                                     {postInfo.fileName}
-                                    {'\t'}
-                                    {generateReadableFileSize()}
+                                    {'\t\t'}
+                                    {generateReadableFileSize(
+                                        postInfo.fileSize
+                                    )}
                                 </Text>
                             </View>
                         </Card.Content>
-                    </Pressable>
-                </Card>
+                    </Button>
+                </View>
             </ScrollView>
         </View>
     );
@@ -93,7 +124,7 @@ const styles = StyleSheet.create({
         flex: 1,
     },
     scrollContent: {
-        padding: designTokens.spacing.xl,
+        padding: designTokens.spacing.md,
         paddingBottom: designTokens.spacing.xxxl,
     },
     headerTitle: {
@@ -108,8 +139,9 @@ const styles = StyleSheet.create({
         padding: designTokens.spacing.xxxl,
         flex: 1,
         flexDirection: 'row',
-        justifyContent: 'center',
-        gap: 24, // alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 24,
+        alignItems: 'center',
     },
     emptyIcon: {
         // marginBottom: designTokens.spacing.lg,
@@ -118,10 +150,12 @@ const styles = StyleSheet.create({
     emptyTitle: {
         marginBottom: designTokens.spacing.sm,
         fontWeight: '600',
+        // textAlign: 'center',
     },
     emptyText: {
         textAlign: 'left',
         opacity: 0.7,
+        // textAlign: 'center',
     },
     cardTextContent: {
         flex: 1,

--- a/mobile/types/api.ts
+++ b/mobile/types/api.ts
@@ -134,4 +134,53 @@ export interface CourseGroup {
     date_assigned: string;
 }
 
-// Module, Post, Quiz, and Progress types removed - these will be implemented by students
+// ============================================================================
+// Post Types
+// ============================================================================
+interface PostBase {
+    id: number;
+    title: string;
+    type: 'generic' | 'attachment' | 'video' | 'quiz';
+    text: string;
+}
+
+export interface PostAttachmentType extends PostBase {
+    pdfUrl: string;
+    fileName: string;
+    fileSize: number;
+}
+
+export interface PostGeneric extends PostBase {
+    image?: string;
+}
+
+export interface PostVideo extends PostBase {
+    vimeoId: string;
+}
+
+export interface PostQuiz extends PostBase {
+    questions: (
+        | MultipleChoiceQuestion
+        | TrueFalseQuestion
+        | SelectAllQuestion
+    )[];
+}
+
+interface QuestionBase {
+    question: string;
+    type: string;
+}
+
+export interface MultipleChoiceQuestion extends QuestionBase {
+    options: string[];
+    validAnswers: number[];
+}
+
+export interface TrueFalseQuestion extends QuestionBase {
+    validAnswers: boolean[];
+}
+
+export interface SelectAllQuestion extends QuestionBase {
+    options: string[];
+    validAnswers: number[];
+}

--- a/mobile/utils/__tests__/generateReadableFileSize.test.ts
+++ b/mobile/utils/__tests__/generateReadableFileSize.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from '@jest/globals';
+import generateReadableFileSize from '../generateReadableFileSize';
+
+describe('PostAttachment', () => {
+    describe('generateReadableFileSize to the properly converted and labeled file size', () => {
+        it('return 7.000 B for a 7 byte file', () => {
+            expect(generateReadableFileSize(7)).toBe('7.000 B');
+        });
+        it('return 984.980 KB for a 984980 byte file', () => {
+            expect(generateReadableFileSize(984980)).toBe('984.980 KB');
+        });
+
+        const byteToMB = 1000000;
+        const finalMBValue = 2.4;
+        it(`return ${finalMBValue.toFixed(3)} MB for a ${finalMBValue * byteToMB} byte file`, () => {
+            expect(generateReadableFileSize(finalMBValue * byteToMB)).toBe(
+                `${finalMBValue.toFixed(3)} MB`
+            );
+        });
+
+        const finalMBValueShouldOverflow = 2000;
+        it(`return ${finalMBValueShouldOverflow.toFixed(3)} GB for a ${finalMBValueShouldOverflow * byteToMB} byte file`, () => {
+            expect(
+                generateReadableFileSize(finalMBValueShouldOverflow * byteToMB)
+            ).toBe(`${(finalMBValueShouldOverflow / 1000).toFixed(3)} GB`);
+        });
+
+        const byteToGB = 1000000000;
+        const finalGBValue = 872.2839;
+        it(`return ${finalGBValue.toFixed(3)} GB for a ${finalGBValue * byteToGB} byte file`, () => {
+            expect(generateReadableFileSize(finalGBValue * byteToGB)).toBe(
+                `${finalGBValue.toFixed(3)} GB`
+            );
+        });
+
+        const byteToTB = 1000000000000;
+        const finalTBValue = 1.7;
+        it(`return ${finalTBValue.toFixed(3)} TB for a ${finalTBValue * byteToTB} byte file`, () => {
+            expect(generateReadableFileSize(finalTBValue * byteToTB)).toBe(
+                `${finalTBValue.toFixed(3)} TB`
+            );
+        });
+    });
+});

--- a/mobile/utils/dummyPost.ts
+++ b/mobile/utils/dummyPost.ts
@@ -1,0 +1,61 @@
+import { PostAttachmentType, PostGeneric, PostQuiz, PostVideo } from '../types';
+
+export const dummyPosts: (
+    | PostGeneric
+    | PostAttachmentType
+    | PostVideo
+    | PostQuiz
+)[] = [
+    {
+        id: 1,
+        title: 'Introduction to React Native',
+        type: 'generic',
+        text: 'React Native is a framework for building mobile apps...',
+        image: 'https://example.com/image.jpg', // optional
+    },
+    {
+        id: 2,
+        title: 'Course Syllabus PDF',
+        type: 'attachment',
+        text: 'Download the course syllabus here.',
+        pdfUrl: 'https://example.com/syllabus.pdf',
+        fileName: 'syllabus.pdf',
+        fileSize: 1024000,
+    },
+    {
+        id: 3,
+        title: 'React Native Tutorial Video',
+        type: 'video',
+        text: 'Watch this video to learn React Native basics.',
+        vimeoId: '123456789', // or vimeoUrl
+    },
+    {
+        id: 4,
+        title: 'Week 1 Quiz',
+        type: 'quiz',
+        text: 'Test your knowledge with this quiz.',
+        questions: [
+            {
+                question: 'What is React Native?',
+                type: 'multiple_choice',
+                options: [
+                    'A web framework',
+                    'A mobile framework',
+                    'A database',
+                ],
+                validAnswers: [1], // index of correct answer
+            },
+            {
+                question: 'React Native uses JavaScript.',
+                type: 'true_false',
+                validAnswers: [true],
+            },
+            {
+                question: 'Which are React Native features?',
+                type: 'select_all',
+                options: ['Cross-platform', 'Hot reload', 'Native performance'],
+                validAnswers: [0, 1, 2], // all are correct
+            },
+        ],
+    },
+];

--- a/mobile/utils/generateReadableFileSize.ts
+++ b/mobile/utils/generateReadableFileSize.ts
@@ -1,0 +1,18 @@
+export default function generateReadableFileSize(fileSize: number) {
+    // File sizes are in bytes originally, ex. 1024000
+    const fileSizeBites = fileSize;
+
+    // bytes to kilobytes
+    const fileSizeKB: number = fileSizeBites / 1000;
+    if (fileSizeKB < 1) return fileSizeBites.toFixed(3) + ' B';
+
+    const fileSizeMB: number = fileSizeKB / 1000;
+    if (fileSizeMB < 1) return fileSizeKB.toFixed(3) + ' KB';
+
+    const fileSizeGB: number = fileSizeMB / 1000;
+    if (fileSizeGB < 1) return fileSizeMB.toFixed(3) + ' MB';
+
+    const fileSizeTB: number = fileSizeGB / 1000;
+    if (fileSizeTB < 1) return fileSizeGB.toFixed(3) + ' GB';
+    return fileSizeTB.toFixed(3) + ' TB';
+}


### PR DESCRIPTION
# PostAttachment
Accomplishes the following, closes #60 :
- Display post title
- Display text content
-  Display a clickable link to the pdf
- Show downloadable PDF attachment
  - Display download button/action (can be a placeholder for now. **I have made a demo of the button being disabled during download by using timeout(), this would be replaced with the actual functionality**)
  - Display file name and size if available
## Display File Name
I made a helper function called generateReadableFileSize(). It is located in `/mobil/utils/generateReadableFileSize.ts`. This function calculates which byte-type the number of bytes (which is how the data is stored for the post) converts best to and returns a string with the converted value and the correct label (B, KB, MB, GB, TB).

I have written multiple jest tests for this function (located in the __tests__ folder in /utils.
# Displaying PostAttachment
During development, I didn't actually have the correct screen (Module Details) to add this component to. To display it, I simply stuck it at the bottom of `/mobile/app/(tabs)/progress.tsx` . I have removed this code, since it shouldn't be in the final code added to main, but here are the lines you can add to display it as I have been. 
Add the import statements: 
```
import PostAttachment from '../../components/posts/PostAttachment';
import { dummyPosts } from '../../utils/dummyPost';
import { PostAttachmentType } from '../../types';
```
Extract the correct dummy data (in the component, but not in the return statement):
```
const attachmentPostData: PostAttachmentType = dummyPosts[1] as PostAttachmentType;
```
Finally, add the component at the bottom. I put it after the scroll view:
```
          </ScrollView>
      <PostAttachment postInfo={attachmentPostData} />
   </View>
````


# Define Types and Dummy Data

Please refer to my previous PR that was merged into main for greater detail on this if needed.